### PR TITLE
First Autosplit at Tutorial_01, Entering Level

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -219,7 +219,7 @@ namespace LiveSplit.HollowKnight {
 
 				GameState gameState = mem.GameState();
 				UIState uiState = mem.UIState();
- +				Model.CurrentState.IsGameTimePaused = ((gameState == GameState.PLAYING || gameState == GameState.ENTERING_LEVEL) && uiState != UIState.PLAYING) || (gameState != GameState.PLAYING && !mem.AcceptingInput()) || gameState == GameState.EXITING_LEVEL || gameState == GameState.LOADING || mem.HeroTransitionState() == HeroTransitionState.WAITING_TO_ENTER_LEVEL || (uiState != UIState.PLAYING && uiState != UIState.PAUSED && (!string.IsNullOrEmpty(nextScene) || sceneName == "_test_charms") && nextScene != sceneName); || sceneName == "_test_charms") && nextScene != sceneName);
+				Model.CurrentState.IsGameTimePaused = ((gameState == GameState.PLAYING || gameState == GameState.ENTERING_LEVEL) && uiState != UIState.PLAYING) || (gameState != GameState.PLAYING && !mem.AcceptingInput()) || gameState == GameState.EXITING_LEVEL || gameState == GameState.LOADING || mem.HeroTransitionState() == HeroTransitionState.WAITING_TO_ENTER_LEVEL || (uiState != UIState.PLAYING && uiState != UIState.PAUSED && (!string.IsNullOrEmpty(nextScene) || sceneName == "_test_charms") && nextScene != sceneName); || sceneName == "_test_charms") && nextScene != sceneName);
 			}
 
 			HandleSplit(shouldSplit);

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -51,7 +51,7 @@ namespace LiveSplit.HollowKnight {
 			bool shouldSplit = false;
 
 			if (currentSplit == -1) {
-				shouldSplit = mem.MenuState() == MainMenuState.PLAY_MODE_MENU && mem.GameState() == GameState.MAIN_MENU && !mem.AcceptingInput();
+				shouldSplit = nextScene.Equals("Tutorial_01", StringComparison.OrdinalIgnoreCase) && mem.GameState() == GameState.ENTERING_LEVEL;
 			} else if (Model.CurrentState.CurrentPhase == TimerPhase.Running) {
 				string nextScene = mem.NextSceneName();
 				string sceneName = mem.SceneName();
@@ -59,7 +59,7 @@ namespace LiveSplit.HollowKnight {
 				if (currentSplit + 1 < Model.CurrentState.Run.Count) {
 					foreach (SplitName split in settings.Splits) {
 						if (splitsDone.Contains(split)) { continue; }
-
+						if( mem.GameState() != GameState.PLAYING) { continue; }
 						switch (split) {
 							case SplitName.AbyssShriek: shouldSplit = mem.PlayerData<int>(Offset.screamLevel) == 2; break;
 							case SplitName.AspidHunter: shouldSplit = mem.PlayerData<int>(Offset.killsSpitter) == 17; break;

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -219,7 +219,7 @@ namespace LiveSplit.HollowKnight {
 
 				GameState gameState = mem.GameState();
 				UIState uiState = mem.UIState();
-				Model.CurrentState.IsGameTimePaused = ((gameState == GameState.PLAYING || gameState == GameState.ENTERING_LEVEL) && uiState != UIState.PLAYING) || (gameState != GameState.PLAYING && !mem.AcceptingInput()) || gameState == GameState.EXITING_LEVEL || gameState == GameState.LOADING || mem.HeroTransitionState() == HeroTransitionState.WAITING_TO_ENTER_LEVEL || (uiState != UIState.PLAYING && uiState != UIState.PAUSED && (!string.IsNullOrEmpty(nextScene) || sceneName == "_test_charms") && nextScene != sceneName); || sceneName == "_test_charms") && nextScene != sceneName);
+				Model.CurrentState.IsGameTimePaused = ((gameState == GameState.PLAYING || gameState == GameState.ENTERING_LEVEL) && uiState != UIState.PLAYING) || (gameState != GameState.PLAYING && !mem.AcceptingInput()) || gameState == GameState.EXITING_LEVEL || gameState == GameState.LOADING || mem.HeroTransitionState() == HeroTransitionState.WAITING_TO_ENTER_LEVEL || (uiState != UIState.PLAYING && uiState != UIState.PAUSED && (!string.IsNullOrEmpty(nextScene) || sceneName == "_test_charms") && nextScene != sceneName);
 			}
 
 			HandleSplit(shouldSplit);

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -218,7 +218,8 @@ namespace LiveSplit.HollowKnight {
 				}
 
 				GameState gameState = mem.GameState();
-				Model.CurrentState.IsGameTimePaused = ((gameState == GameState.PLAYING || gameState == GameState.ENTERING_LEVEL) && mem.UIState() != UIState.PLAYING) || (gameState != GameState.PLAYING && !mem.AcceptingInput()) || gameState == GameState.EXITING_LEVEL || gameState == GameState.LOADING || mem.HeroTransitionState() == HeroTransitionState.WAITING_TO_ENTER_LEVEL || ((!string.IsNullOrEmpty(nextScene) || sceneName == "_test_charms") && nextScene != sceneName);
+				UIState uiState = mem.UIState();
+ +				Model.CurrentState.IsGameTimePaused = ((gameState == GameState.PLAYING || gameState == GameState.ENTERING_LEVEL) && uiState != UIState.PLAYING) || (gameState != GameState.PLAYING && !mem.AcceptingInput()) || gameState == GameState.EXITING_LEVEL || gameState == GameState.LOADING || mem.HeroTransitionState() == HeroTransitionState.WAITING_TO_ENTER_LEVEL || (uiState != UIState.PLAYING && uiState != UIState.PAUSED && (!string.IsNullOrEmpty(nextScene) || sceneName == "_test_charms") && nextScene != sceneName); || sceneName == "_test_charms") && nextScene != sceneName);
 			}
 
 			HandleSplit(shouldSplit);

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -49,12 +49,13 @@ namespace LiveSplit.HollowKnight {
 #if !Info
 		private void HandleSplits() {
 			bool shouldSplit = false;
-
+			string nextScene = mem.NextSceneName();
+			string sceneName = mem.SceneName();
+			
 			if (currentSplit == -1) {
 				shouldSplit = nextScene.Equals("Tutorial_01", StringComparison.OrdinalIgnoreCase) && mem.GameState() == GameState.ENTERING_LEVEL;
 			} else if (Model.CurrentState.CurrentPhase == TimerPhase.Running) {
-				string nextScene = mem.NextSceneName();
-				string sceneName = mem.SceneName();
+				
 
 				if (currentSplit + 1 < Model.CurrentState.Run.Count) {
 					foreach (SplitName split in settings.Splits) {

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("b3294e28-2bd4-4e39-92fa-e04a620c7e77")]
-[assembly: AssemblyVersion("2.1.5.0")]
-[assembly: AssemblyFileVersion("2.1.5.0")]
+[assembly: AssemblyVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.2.0.0")]
 #if !Info
 [assembly: ComponentFactory(typeof(HollowKnightFactory))]
 #endif

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Hollow Knight Autosplitter / Load Remover
 
 ## Setting up the autosplitter in LiveSplit
-- Go to the [releases](https://github.com/ShootMe/LiveSplit.HollowKnight/releases) section in this repository.
+- Go to the [releases](https://github.com/KayDeeTee/LiveSplit.HollowKnight/releases) section in this repository.
 - Download the latest LiveSplit.HollowKnight.dll
 - Place the LiveSplit.HollowKnight.dll inside the LiveSplit/Components folder
 - Open LiveSplit, edit your layout, add Control -> Hollow Knight Autosplitter

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # LiveSplit.HollowKnight
 Hollow Knight Autosplitter / Load Remover
 
-This fork should cause the autosplitter to start at the very start of the first scene, removing randomness due to load times from the first 5 - 8 seconds of a run,
-It should hopefully also prevent S+Q split bugs
-
 ## Setting up the autosplitter in LiveSplit
-- Go to the [releases](https://github.com/KayDeeTee/LiveSplit.HollowKnight/releases) section in this repository.
+- Go to the [releases](https://github.com/ShootMe/LiveSplit.HollowKnight/releases) section in this repository.
 - Download the latest LiveSplit.HollowKnight.dll
 - Place the LiveSplit.HollowKnight.dll inside the LiveSplit/Components folder
 - Open LiveSplit, edit your layout, add Control -> Hollow Knight Autosplitter

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # LiveSplit.HollowKnight
 Hollow Knight Autosplitter / Load Remover
 
+This fork should cause the autosplitter to start at the very start of the first scene, removing randomness due to load times from the first 5 - 8 seconds of a run,
+It should hopefully also prevent S+Q split bugs
+
 ## Setting up the autosplitter in LiveSplit
 - Go to the [releases](https://github.com/KayDeeTee/LiveSplit.HollowKnight/releases) section in this repository.
 - Download the latest LiveSplit.HollowKnight.dll


### PR DESCRIPTION
Removes a random amount of load speed dependent time (usually 4-8 seconds) at the start of the run,
It should also remove S+Q splits, however it's hard to test if s+q splits are fixed because they are very rare in any% but in theory only splitting whilst playing should prevent it.