### PR TITLE
SalubraExit

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -922,6 +922,7 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.EnterCrown: shouldSplit = nextScene.Equals("Mines_23") && nextScene != sceneName; break;
                 case SplitName.EnterDirtmouth: shouldSplit = nextScene.Equals("Town") && nextScene != sceneName; break;
                 case SplitName.EnterRafters: shouldSplit = nextScene.Equals("Ruins1_03") && nextScene != sceneName; break;
+                case SplitName.SalubraExit: shouldSplit = sceneName.Equals("Room_Charm_Shop") && nextScene != sceneName; break;
 
                 case SplitName.FailedChampionEssence: shouldSplit = mem.PlayerData<bool>(Offset.falseKnightOrbsCollected); break;
                 case SplitName.SoulTyrantEssence: shouldSplit = mem.PlayerData<bool>(Offset.mageLordOrbsCollected); break;

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -721,6 +721,8 @@ namespace LiveSplit.HollowKnight {
         EnterCrown,
         [Description("Rafters (Transition)"), ToolTip("Splits on any transition into the City Rafters room")]
         EnterRafters,
+        [Description("Salubra Exit (Transition)", ToolTip("Splits on the transition out of Salubra's Hut"))]
+        SalubraExit,
 
         [Description("Has Claw (Transition)"), ToolTip("Splits on transition after Mantis Claw acquired")]
         TransClaw,


### PR DESCRIPTION
Adds a `SalubraExit` split on the transition out of Salubra's Hut.

I cannot build or test this for now.