### PR TITLE
Splits GreatHuskSentry, SpireBenchExit

### DIFF
--- a/Enums.cs
+++ b/Enums.cs
@@ -201,6 +201,7 @@
         spiderCapture,
         unchainedHollowKnight,
         killedGiantHopper,
+        killedGreatShieldZombie,
         killedGorgeousHusk,
         gladeDoorOpened,
         killedLazyFlyer,

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -379,6 +379,7 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.GrubberflysElegy: shouldSplit = mem.PlayerData<bool>(Offset.gotCharm_35); break;
                 case SplitName.Grubsong: shouldSplit = mem.PlayerData<bool>(Offset.gotCharm_3); break;
                 case SplitName.GreatHopper: shouldSplit = mem.PlayerData<bool>(Offset.killedGiantHopper); break;
+                case SplitName.GreatHuskSentry: shouldSplit = mem.PlayerData<bool>(Offset.killedGreatShieldZombie); break;
                 case SplitName.GreyPrince: shouldSplit = mem.PlayerData<bool>(Offset.killedGreyPrince); break;
                 case SplitName.GruzMother: shouldSplit = mem.PlayerData<bool>(Offset.killedBigFly); break;
                 case SplitName.HeavyBlow: shouldSplit = mem.PlayerData<bool>(Offset.gotCharm_15); break;
@@ -930,6 +931,8 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.EnterDirtmouth: shouldSplit = nextScene.Equals("Town") && nextScene != sceneName; break;
                 case SplitName.EnterRafters: shouldSplit = nextScene.Equals("Ruins1_03") && nextScene != sceneName; break;
                 case SplitName.SalubraExit: shouldSplit = sceneName.Equals("Room_Charm_Shop") && nextScene != sceneName; break;
+                // since Ruins1_18 has both bench and bridge, don't include Ruins1_18 bridge to Ruins2_03b
+                case SplitName.SpireBenchExit: shouldSplit = sceneName.StartsWith("Ruins1_18") && nextScene.StartsWith("Ruins2_01"); break;
 
                 case SplitName.FailedChampionEssence: shouldSplit = mem.PlayerData<bool>(Offset.falseKnightOrbsCollected); break;
                 case SplitName.SoulTyrantEssence: shouldSplit = mem.PlayerData<bool>(Offset.mageLordOrbsCollected); break;

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -596,6 +596,8 @@ namespace LiveSplit.HollowKnight {
         HuskMiner,
         [Description("Great Hopper (Killed)"), ToolTip("Splits when killing a Great Hopper")]
         GreatHopper,
+        [Description("Great Husk Sentry (Killed)"), ToolTip("Splits when killing a Great Husk Sentry")]
+        GreatHuskSentry,
         [Description("Gorgeous Husk (Killed)"), ToolTip("Splits when killing Gorgeous Husk")]
         GorgeousHusk,
         [Description("Menderbug (Killed)"), ToolTip("Splits when killing Menderbug")]
@@ -736,6 +738,8 @@ namespace LiveSplit.HollowKnight {
         EnterRafters,
         [Description("Salubra Exit (Transition)"), ToolTip("Splits on the transition out of Salubra's Hut")]
         SalubraExit,
+        [Description("Spire Bench Exit (Transition)"), ToolTip("Splits on the transition out of the bench room in Watcher's Spire")]
+        SpireBenchExit,
 
         [Description("Has Claw (Transition)"), ToolTip("Splits on transition after Mantis Claw acquired")]
         TransClaw,


### PR DESCRIPTION
Testing:
- [ ] `GreatHuskSentry` splits when killing the first Great Husk Sentry
- [ ] `SpireBenchExit` splits when exiting the bench room in Spire
- [ ] `SpireBenchExit` should not split when exiting the Spire Bridge room