### PR TITLE
Add a Hit counter

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -262,12 +262,6 @@ namespace LiveSplit.HollowKnight {
                 Model.CurrentState.Run.Metadata.SetCustomVariable("comparison hits", TimeFormatConstants.DASH);
                 Model.CurrentState.Run.Metadata.SetCustomVariable("delta hits", TimeFormatConstants.DASH);
             }
-            while (cumulativeHits.Count < currentSplit) {
-                cumulativeHits.Add(hits);
-            }
-            if (currentSplit >= 1) {
-                cumulativeHits[currentSplit - 1] = hits;
-            }
         }
 
         private void HandleHits(GameState gameState, UIState _uIState, string _nextScene, string sceneName) {
@@ -2356,6 +2350,9 @@ namespace LiveSplit.HollowKnight {
             segmentHits[currentSplit] += segmentHits[currentSplit + 1];
             segmentHits[currentSplit + 1] = 0;
             HitsIndexChanged();
+            if (currentSplit < cumulativeHits.Count) {
+                cumulativeHits.RemoveRange(currentSplit, cumulativeHits.Count - currentSplit);
+            }
             //if (!settings.Ordered) splitsDone.Remove(lastSplitDone); Reminder of THIS BREAKS THINGS
             state = 0;
             menuSplitHelper = false;
@@ -2376,6 +2373,12 @@ namespace LiveSplit.HollowKnight {
         public void OnSplit(object sender, EventArgs e) {
             currentSplit++;
             HitsIndexChanged();
+            while (cumulativeHits.Count < currentSplit) {
+                cumulativeHits.Add(hits);
+            }
+            if (currentSplit >= 1) {
+                cumulativeHits[currentSplit - 1] = hits;
+            }
             state = 0;
             menuSplitHelper = false;
             menuSplitCountdown = 20;

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -265,8 +265,6 @@ namespace LiveSplit.HollowKnight {
         }
 
         private void HandleHits(GameState gameState, UIState _uIState, string _nextScene, string sceneName) {
-            // TODO: set segment hits to 0 when moving to a new segment, also reset delta hits at the same time
-            // TODO: also reset these when resetting the run
             if (settings.HitCounter is HollowKnightSettings.HitsMethod.None) {
                 return;
             }

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -2351,7 +2351,14 @@ namespace LiveSplit.HollowKnight {
             segmentHits[currentSplit + 1] = 0;
             HitsIndexChanged();
             if (currentSplit < cumulativeHits.Count) {
-                cumulativeHits.RemoveRange(currentSplit, cumulativeHits.Count - currentSplit);
+                int i = currentSplit;
+                // go back through skipped splits
+                while (1 <= i && Model.CurrentState.Run[i - 1].SplitTime.RealTime == null) {
+                    i--;
+                }
+                // Run[i - 1] was not skipped, but Run[i] was skipped or undone,
+                // so remove cumulativeHits from there on
+                cumulativeHits.RemoveRange(i, cumulativeHits.Count - i);
             }
             //if (!settings.Ordered) splitsDone.Remove(lastSplitDone); Reminder of THIS BREAKS THINGS
             state = 0;

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -94,7 +94,11 @@ namespace LiveSplit.HollowKnight {
                 state.OnSkipSplit += OnSkipSplit;
                 state.Run.Metadata.SetCustomVariable("hits", "0");
                 state.Run.Metadata.SetCustomVariable("segment hits", "0");
-                state.Run.Metadata.SetCustomVariable("pb hits", TimeFormatConstants.DASH);
+                if (settings.ComparisonHits.Count == state.Run.Count) {
+                    state.Run.Metadata.SetCustomVariable("pb hits", settings.ComparisonHits[settings.ComparisonHits.Count - 1].ToString());
+                } else {
+                    state.Run.Metadata.SetCustomVariable("pb hits", TimeFormatConstants.DASH);
+                }
                 state.Run.Metadata.SetCustomVariable("comparison hits", TimeFormatConstants.DASH);
                 state.Run.Metadata.SetCustomVariable("delta hits", TimeFormatConstants.DASH);
 
@@ -2379,7 +2383,16 @@ namespace LiveSplit.HollowKnight {
             store.Update();
         }
         public Control GetSettingsControl(LayoutMode mode) { return settings; }
-        public void SetSettings(XmlNode document) { settings.SetSettings(document); }
+        public void SetSettings(XmlNode document) {
+            settings.SetSettings(document);
+            if (Model != null) {
+                if (settings.ComparisonHits.Count == Model.CurrentState.Run.Count) {
+                    Model.CurrentState.Run.Metadata.SetCustomVariable("pb hits", settings.ComparisonHits[settings.ComparisonHits.Count - 1].ToString());
+                } else {
+                    Model.CurrentState.Run.Metadata.SetCustomVariable("pb hits", TimeFormatConstants.DASH);
+                }
+            }
+        }
         public XmlNode GetSettings(XmlDocument document) { return settings.UpdateSettings(document); }
         public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion) { }
         public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion) { }

--- a/HollowKnightMemory.cs
+++ b/HollowKnightMemory.cs
@@ -13,7 +13,7 @@ namespace LiveSplit.HollowKnight {
         public bool IsHooked { get; set; }
         private DateTime lastHooked;
         private int uiManager, inputHandler, cameraCtrl, gameState, heroController, camTarget, camMode, camTMode, camDest, menuState, uiState, achievementHandler;
-        private int heroAccepting, actorState, transistionState, camTeleport, playerData, debugInfo, tilemapDirty, cState, sceneName, nextSceneName, entryGateName, hazardRespawning, onGround, spellquake, focusing;
+        private int heroAccepting, actorState, transistionState, camTeleport, playerData, debugInfo, tilemapDirty, cState, sceneName, nextSceneName, entryGateName, hazardDeath, hazardRespawning, onGround, recoilFrozen, spellquake, focusing;
         //private int sceneData, awardAchievementEvent;
         private Version lastVersion;
 
@@ -60,8 +60,10 @@ namespace LiveSplit.HollowKnight {
             heroAccepting = 0x457;
             actorState = 0x374;
             transistionState = 0x37c;
+            hazardDeath = 0x25; // best guess, TODO actually check
             hazardRespawning = 0x26;
             onGround = 0x9;
+            recoilFrozen = 0x28; // best guess, TODO actually check
             spellquake = 0x37;
             focusing = 0x39;
 
@@ -103,8 +105,10 @@ namespace LiveSplit.HollowKnight {
                 heroAccepting = 0x6e7;
 
                 //HeroControllerStates
+                hazardDeath = 0x2d;
                 hazardRespawning = 0x2e;
                 onGround = 0x11;
+                recoilFrozen = 0x30;
                 spellquake = 0x3f;
                 focusing = 0x41;
 
@@ -440,6 +444,10 @@ namespace LiveSplit.HollowKnight {
             //GameManager._instance.tileMapDirty
             return gameManager.Read<bool>(Program, 0x0, tilemapDirty);
         }
+        public bool HazardDeath() {
+            //GameManager._instance.hero_ctrl.cState.hazardDeath
+            return gameManager.Read<bool>(Program, 0x0, heroController, cState, hazardDeath);
+        }
         public bool HazardRespawning() {
             //GameManager._instance.hero_ctrl.cState.hazardRespawning
             return gameManager.Read<bool>(Program, 0x0, heroController, cState, hazardRespawning);
@@ -447,6 +455,10 @@ namespace LiveSplit.HollowKnight {
         public bool OnGround() {
             //GameManager._instance.hero_ctrl.cState.onGround
             return gameManager.Read<bool>(Program, 0x0, heroController, cState, onGround);
+        }
+        public bool RecoilFrozen() {
+            //GameManager._instance.hero_ctrl.cState.recoilFrozen
+            return gameManager.Read<bool>(Program, 0x0, heroController, cState, recoilFrozen);
         }
         public bool Spellquake() {
             //GameManager._instance.hero_ctrl.cState.spellquake

--- a/HollowKnightSettings.Designer.cs
+++ b/HollowKnightSettings.Designer.cs
@@ -34,6 +34,8 @@
             this.chkAutosplitStartRuns = new System.Windows.Forms.CheckBox();
             this.chkOrdered = new System.Windows.Forms.CheckBox();
             this.chkAutosplitEndRuns = new System.Windows.Forms.CheckBox();
+            this.hitCounterLabel = new System.Windows.Forms.Label();
+            this.cboHitCounter = new System.Windows.Forms.ComboBox();
             this.SortBy_GroupBox = new System.Windows.Forms.GroupBox();
             this.rdAlpha = new System.Windows.Forms.RadioButton();
             this.rdType = new System.Windows.Forms.RadioButton();
@@ -47,7 +49,7 @@
             // 
             // btnAddSplit
             // 
-            this.btnAddSplit.Location = new System.Drawing.Point(6, 92);
+            this.btnAddSplit.Location = new System.Drawing.Point(6, 119);
             this.btnAddSplit.Name = "btnAddSplit";
             this.btnAddSplit.Size = new System.Drawing.Size(57, 21);
             this.btnAddSplit.TabIndex = 0;
@@ -67,7 +69,7 @@
             this.flowMain.Location = new System.Drawing.Point(0, 0);
             this.flowMain.Margin = new System.Windows.Forms.Padding(0);
             this.flowMain.Name = "flowMain";
-            this.flowMain.Size = new System.Drawing.Size(456, 129);
+            this.flowMain.Size = new System.Drawing.Size(456, 156);
             this.flowMain.TabIndex = 0;
             this.flowMain.WrapContents = false;
             this.flowMain.DragDrop += new System.Windows.Forms.DragEventHandler(this.flowMain_DragDrop);
@@ -82,7 +84,7 @@
             this.flowOptions.Location = new System.Drawing.Point(0, 0);
             this.flowOptions.Margin = new System.Windows.Forms.Padding(0);
             this.flowOptions.Name = "flowOptions";
-            this.flowOptions.Size = new System.Drawing.Size(456, 129);
+            this.flowOptions.Size = new System.Drawing.Size(456, 156);
             this.flowOptions.TabIndex = 0;
             // 
             // Options_GroupBox
@@ -93,14 +95,14 @@
             this.Options_GroupBox.Controls.Add(this.SortBy_GroupBox);
             this.Options_GroupBox.Location = new System.Drawing.Point(3, 3);
             this.Options_GroupBox.Name = "Options_GroupBox";
-            this.Options_GroupBox.Size = new System.Drawing.Size(450, 123);
+            this.Options_GroupBox.Size = new System.Drawing.Size(450, 150);
             this.Options_GroupBox.TabIndex = 6;
             this.Options_GroupBox.TabStop = false;
             this.Options_GroupBox.Text = "Options";
             // 
             // versionLabel
             // 
-            this.versionLabel.Location = new System.Drawing.Point(262, 89);
+            this.versionLabel.Location = new System.Drawing.Point(262, 116);
             this.versionLabel.Name = "versionLabel";
             this.versionLabel.Size = new System.Drawing.Size(182, 24);
             this.versionLabel.TabIndex = 7;
@@ -113,9 +115,11 @@
             this.RunBehaviour_GroupBox.Controls.Add(this.chkAutosplitStartRuns);
             this.RunBehaviour_GroupBox.Controls.Add(this.chkOrdered);
             this.RunBehaviour_GroupBox.Controls.Add(this.chkAutosplitEndRuns);
+            this.RunBehaviour_GroupBox.Controls.Add(this.hitCounterLabel);
+            this.RunBehaviour_GroupBox.Controls.Add(this.cboHitCounter);
             this.RunBehaviour_GroupBox.Location = new System.Drawing.Point(143, 15);
             this.RunBehaviour_GroupBox.Name = "RunBehaviour_GroupBox";
-            this.RunBehaviour_GroupBox.Size = new System.Drawing.Size(301, 71);
+            this.RunBehaviour_GroupBox.Size = new System.Drawing.Size(301, 98);
             this.RunBehaviour_GroupBox.TabIndex = 7;
             this.RunBehaviour_GroupBox.TabStop = false;
             this.RunBehaviour_GroupBox.Text = "Run behaviour";
@@ -164,6 +168,24 @@
             this.ToolTips.SetToolTip(this.chkAutosplitEndRuns, "Any autosplit can stop the timer on final split to finish a run");
             this.chkAutosplitEndRuns.UseVisualStyleBackColor = true;
             this.chkAutosplitEndRuns.CheckedChanged += new System.EventHandler(this.AutosplitEndChanged);
+            // 
+            // hitCounterLabel
+            // 
+            this.hitCounterLabel.Location = new System.Drawing.Point(6, 69);
+            this.hitCounterLabel.Name = "hitCounterLabel";
+            this.hitCounterLabel.Size = new System.Drawing.Size(139, 21);
+            this.hitCounterLabel.TabIndex = 7;
+            this.hitCounterLabel.Text = "Hit counter:";
+            this.hitCounterLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // cboHitCounter
+            // 
+            this.cboHitCounter.FormattingEnabled = true;
+            this.cboHitCounter.Location = new System.Drawing.Point(148, 69);
+            this.cboHitCounter.Name = "cboHitCounter";
+            this.cboHitCounter.Size = new System.Drawing.Size(145, 21);
+            this.cboHitCounter.TabIndex = 7;
+            this.cboHitCounter.SelectedIndexChanged += new System.EventHandler(this.cboHitCounter_SelectedIndexChanged);
             // 
             // SortBy_GroupBox
             // 
@@ -214,7 +236,7 @@
             this.Controls.Add(this.flowMain);
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "HollowKnightSettings";
-            this.Size = new System.Drawing.Size(456, 129);
+            this.Size = new System.Drawing.Size(456, 150);
             this.Load += new System.EventHandler(this.Settings_Load);
             this.flowMain.ResumeLayout(false);
             this.flowMain.PerformLayout();
@@ -244,5 +266,7 @@
         private System.Windows.Forms.GroupBox SortBy_GroupBox;
         private System.Windows.Forms.CheckBox chkAutosplitStartRuns;
         private System.Windows.Forms.ComboBox cboStartTriggerName;
+        private System.Windows.Forms.Label hitCounterLabel;
+        private System.Windows.Forms.ComboBox cboHitCounter;
     }
 }


### PR DESCRIPTION
Adds a Hit counter, now that https://github.com/LiveSplit/LiveSplit/pull/2528 has gone through into a main release. This works with LiveSplit custom variables, compatible with the [`LiveSplit.HitCounterManagerConnector`](https://github.com/topeterk/LiveSplit.HitCounterManagerConnector) component to send hits to [`HitCounterManager`](https://github.com/topeterk/HitCounterManager).

The Hit counter sets these LiveSplit Custom Variables:
- `hits` cumulative hits so far in the current run
- `pb hits` the minimum number of total hits in previous finished runs
- `delta hits` difference between current run `hits` and "best-pace" hits
- `segment hits` hits in this segment of the current run

Also adds a setting for the Hit counter which can either be:
- `None` no hit counter
- `Hits / dream falls` includes falling in dream plats as a hit, as well as the normal things
- `Hits / damage` does not count falling in dream plats as a hit

For local testing, I also have a branch with the DLL built here: https://github.com/AlexKnauth/LiveSplit.HollowKnight/tree/hits-dll

Tasks:
- [x] Test behavior on skip split, make sure that segment hits get transferred to the new current split.
  - A -> B: on A, get hit, skip A, and the hit should now be shown on B, not A. get hit again, and it should add on to B
- [x] Test behavior on undo split, make sure that it also undoes any change to the ComparisonHits that might have come from the split that needed to be undone.
  - A -> B: on A, get hit twice, split A, split B, end, reset. ComparisonHits should have [2, 2]
  - manually split A without getting hit, then get hit once, undo A, split A, split B, end, reset. ComparisonHits should have [1, 1]
- [x] Fix `pb hits` on startup.
- [x] Test behavior on skipped split pace comparisons, so that skipping a split on a low number of hits, does not save as a good pace as if you had completed the split.
  - A -> B -> C -> D: on A, get hit, split A, get hit, skip B, get hit, skip C, and get hit again on D. ComparisonHits should have [1, 4, 4, 4]
  - A -> B -> C -> D -> E: on A, get hit, split A, get hit, skip B, get hit, skip C, and get hit again on D. split D, get hit, undo D, then a bunch of splits, undos, skips, hits, etc. around D before finally splitting E and ending. ComparisonHits should have [1, N, N, N, N] where N is the total hits
- [x] Test importing ComparisonHits from WASM-autosplitter splits files