### PR TITLE
Updated start and end splits

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -301,19 +301,6 @@ namespace LiveSplit.HollowKnight {
 
                 #region Start and End
 
-                case SplitName.LegacyStart:
-                    shouldSplit =
-                        (nextScene.Equals("Tutorial_01", StringComparison.OrdinalIgnoreCase)
-                            && mem.GameState() == GameState.ENTERING_LEVEL)
-                        || nextScene is "GG_Vengefly_V" or "GG_Boss_Door_Entrance" or "GG_Entrance_Cutscene";
-                    break;
-
-                case SplitName.LegacyEnd:
-                    shouldSplit =
-                        nextScene.StartsWith("Cinematic_Ending", StringComparison.OrdinalIgnoreCase)
-                        || nextScene == "GG_End_Sequence";
-                    break;
-
                 case SplitName.StartNewGame:
                     shouldSplit =
                         (nextScene.Equals("Tutorial_01", StringComparison.OrdinalIgnoreCase)

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -291,12 +291,56 @@ namespace LiveSplit.HollowKnight {
 
 
         private SplitterAction CheckSplit(SplitName split, string nextScene, string sceneName) {
+            string currScene = sceneName;
             bool shouldSplit = false;
             bool shouldSkip = false;
             bool shouldReset = false;
             SplitterAction action;
 
             switch (split) {
+
+                #region Start and End
+
+                case SplitName.LegacyStart:
+                    shouldSplit =
+                        (nextScene.Equals("Tutorial_01", StringComparison.OrdinalIgnoreCase)
+                            && mem.GameState() == GameState.ENTERING_LEVEL)
+                        || nextScene is "GG_Vengefly_V" or "GG_Boss_Door_Entrance" or "GG_Entrance_Cutscene";
+                    break;
+
+                case SplitName.LegacyEnd:
+                    shouldSplit =
+                        nextScene.StartsWith("Cinematic_Ending", StringComparison.OrdinalIgnoreCase)
+                        || nextScene == "GG_End_Sequence";
+                    break;
+
+                case SplitName.StartNewGame:
+                    shouldSplit =
+                        (nextScene.Equals("Tutorial_01", StringComparison.OrdinalIgnoreCase)
+                        && mem.GameState() == GameState.ENTERING_LEVEL)
+                        || nextScene is "GG_Entrance_Cutscene";
+                    break;
+                case SplitName.StartPantheon:
+                    shouldSplit =
+                        nextScene is "GG_Vengefly_V" or "GG_Boss_Door_Entrance";
+                    break;
+
+                case SplitName.RandoWake:
+                    shouldSplit =
+                        !mem.PlayerData<bool>(Offset.disablePause)
+                        && mem.GameState() == GameState.PLAYING
+                        && !menuingSceneNames.Contains(currScene);
+                    break;
+
+                case SplitName.EndingSplit: shouldSplit = nextScene.StartsWith("Cinematic_Ending", StringComparison.OrdinalIgnoreCase); break;
+                case SplitName.EndingA: shouldSplit = nextScene.Equals("Cinematic_Ending_A", StringComparison.OrdinalIgnoreCase); break;
+                case SplitName.EndingB: shouldSplit = nextScene.Equals("Cinematic_Ending_B", StringComparison.OrdinalIgnoreCase); break;
+                case SplitName.EndingC: shouldSplit = nextScene.Equals("Cinematic_Ending_C", StringComparison.OrdinalIgnoreCase); break;
+                case SplitName.EndingD: shouldSplit = nextScene.Equals("Cinematic_Ending_D", StringComparison.OrdinalIgnoreCase); break;
+                case SplitName.EndingE: shouldSplit = nextScene.Equals("Cinematic_Ending_E", StringComparison.OrdinalIgnoreCase); break;
+
+                #endregion Start and End
+
                 case SplitName.Abyss: shouldSplit = mem.PlayerData<bool>(Offset.visitedAbyss); break;
                 case SplitName.AbyssShriek: shouldSplit = mem.PlayerData<int>(Offset.screamLevel) == 2; break;
                 case SplitName.Aluba: shouldSplit = mem.PlayerData<bool>(Offset.killedLazyFlyer); break;
@@ -1096,9 +1140,6 @@ namespace LiveSplit.HollowKnight {
                         shouldSplit = !(debugSaveStateSceneNames.Contains(nextScene) || debugSaveStateSceneNames.Contains(sceneName));
                     }
                     break;
-                case SplitName.RandoWake:
-                    shouldSplit = !mem.PlayerData<bool>(Offset.disablePause) && mem.GameState() == GameState.PLAYING && !menuingSceneNames.Contains(sceneName);
-                    break;
                 case SplitName.OnGhostCoinsIncremented:
                     shouldSplit = store.CheckIncremented(Offset.ghostCoins);
                     break;
@@ -1192,7 +1233,6 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.ColosseumSilverExit: shouldSplit = mem.PlayerData<bool>(Offset.colosseumSilverCompleted) && !nextScene.StartsWith("Room_Colosseum_Silver") && nextScene != sceneName; break;
                 case SplitName.ColosseumGoldExit: shouldSplit = mem.PlayerData<bool>(Offset.colosseumGoldCompleted) && !nextScene.StartsWith("Room_Colosseum_Gold") && nextScene != sceneName; break;
                 case SplitName.SoulTyrantEssenceWithSanctumGrub: shouldSplit = mem.PlayerData<bool>(Offset.mageLordOrbsCollected) && mem.PlayerDataStringList(Offset.scenesGrubRescued).Contains("Ruins1_32"); break;
-                case SplitName.EndingSplit: shouldSplit = nextScene.StartsWith("Cinematic_Ending", StringComparison.OrdinalIgnoreCase) || nextScene == "GG_End_Sequence"; break;
 
                 case SplitName.EnterHornet1: shouldSplit = nextScene.StartsWith("Fungus1_04") && nextScene != sceneName; break;
                 case SplitName.EnterSoulMaster: shouldSplit = nextScene.StartsWith("Ruins1_24") && nextScene != sceneName; break;

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -58,6 +58,33 @@ namespace LiveSplit.HollowKnight {
         }
     }
     public enum SplitName {
+
+        [Description("[DEPRECATED] Start Run (Start)"), ToolTip("Splits when autosplitter version 3 would have automatically started runs")]
+        LegacyStart,
+
+        [Description("Start New Game (Start)"), ToolTip("Splits when starting a new game, including Normal, Steel Soul, and Godseeker mode")]
+        StartNewGame,
+        [Description("Start Pantheon (Start)"), ToolTip("Splits when starting a Pantheon run")]
+        StartPantheon,
+        [Description("Rando Wake (Start)"), ToolTip("Splits when gaining control after waking up in Rando")]
+        RandoWake,
+
+        [Description("[DEPRECATED] End Run (Ending)"), ToolTip("Splits when autosplitter version 3 would have automatically ended runs")]
+        LegacyEnd,
+
+        [Description("Credits Roll (Ending)"), ToolTip("Splits on any credits rolling")]
+        EndingSplit,
+        [Description("The Hollow Knight (Ending)"), ToolTip("Splits on The Hollow Knight ending")]
+        EndingA,
+        [Description("Sealed Siblings (Ending)"), ToolTip("Splits on Sealed Siblings ending")]
+        EndingB,
+        [Description("Dream No More (Ending)"), ToolTip("Splits on Dream No More ending")]
+        EndingC,
+        [Description("Embrace the Void (Ending)"), ToolTip("Splits on Embrace the Void ending")]
+        EndingD,
+        [Description("Delicate Flower (Ending)"), ToolTip("Splits on Delicate Flower ending")]
+        EndingE,
+
         [Description("Abyss Shriek (Skill)"), ToolTip("Splits when obtaining Abyss Shriek")]
         AbyssShriek,
         [Description("Crystal Heart (Skill)"), ToolTip("Splits when obtaining Crystal Heart")]
@@ -505,8 +532,6 @@ namespace LiveSplit.HollowKnight {
         CityGateOpen,
         [Description("City Gate w/ Mantis Lords defeated (Event)"), ToolTip("To make sure you don't forget Mantis Lords")]
         CityGateAndMantisLords,
-        [Description("Credits Roll (Event)"), ToolTip("Splits on any credits rolling")]
-        EndingSplit,
         [Description("Death (Event)"), ToolTip("Splits when player HP is 0")]
         PlayerDeath,
         [Description("Shade Killed (Event)"), ToolTip("Splits when the Shade is killed")]
@@ -1639,8 +1664,6 @@ namespace LiveSplit.HollowKnight {
         TransitionAfterSaveState,
         [Description("Manual Split (Misc)"), ToolTip("Never splits. Use this when you need to manually split while using ordered splits")]
         ManualSplit,
-        [Description("Rando Wake (Event)"), ToolTip("Splits when gaining control after waking up in Rando")]
-        RandoWake,
         [Description("Ghost Coins Incremented (Event)"), ToolTip("Splits when the ghostCoins PlayerData is updated. Unused by unmodded game, intended for use with mods.")]
         OnGhostCoinsIncremented,
 

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -59,18 +59,12 @@ namespace LiveSplit.HollowKnight {
     }
     public enum SplitName {
 
-        [Description("[DEPRECATED] Start Run (Start)"), ToolTip("Splits when autosplitter version 3 would have automatically started runs")]
-        LegacyStart,
-
         [Description("Start New Game (Start)"), ToolTip("Splits when starting a new game, including Normal, Steel Soul, and Godseeker mode")]
         StartNewGame,
         [Description("Start Pantheon (Start)"), ToolTip("Splits when starting a Pantheon run")]
         StartPantheon,
         [Description("Rando Wake (Start)"), ToolTip("Splits when gaining control after waking up in Rando")]
         RandoWake,
-
-        [Description("[DEPRECATED] End Run (Ending)"), ToolTip("Splits when autosplitter version 3 would have automatically ended runs")]
-        LegacyEnd,
 
         [Description("Credits Roll (Ending)"), ToolTip("Splits on any credits rolling")]
         EndingSplit,


### PR DESCRIPTION
Adds StartNewGame and StartPantheon, which can be used with StartTriggeringAutosplit or regular Splits.

Adds EndingA through EndingE to differentiate between the 5 different endings.