### PR TITLE
Updated transitions

### DIFF
--- a/Enums.cs
+++ b/Enums.cs
@@ -283,6 +283,7 @@
         equippedCharm_28,
 
         equippedCharm_23,
+        equippedCharm_40,
         brokenCharm_23,
         brokenCharm_24,
         brokenCharm_25,

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -563,142 +563,142 @@ namespace LiveSplit.HollowKnight {
 
                 // these aren't really sorted, there's so many and my brain can only handle so much split sorting, maybe next update
 
-                case SplitName.AncestralMound: shouldSplit = nextScene.Equals("Crossroads_ShamanTemple") && nextScene != sceneName; break;
-                case SplitName.TransCollector: shouldSplit = mem.PlayerData<bool>(Offset.collectorDefeated) && sceneName.StartsWith("Ruins2_11") && nextScene != sceneName; break;
-                case SplitName.TeachersArchive: shouldSplit = sceneName.Equals("Fungus3_archive", StringComparison.OrdinalIgnoreCase); break;
-                case SplitName.TransVS: shouldSplit = mem.PlayerData<int>(Offset.fireballLevel) == 1 && nextScene != sceneName; break;
+                case SplitName.AncestralMound: shouldSplit = nextScene.Equals("Crossroads_ShamanTemple") && nextScene != currScene; break;
+                case SplitName.TransCollector: shouldSplit = mem.PlayerData<bool>(Offset.collectorDefeated) && currScene.StartsWith("Ruins2_11") && nextScene != currScene; break;
+                case SplitName.TeachersArchive: shouldSplit = currScene.Equals("Fungus3_archive", StringComparison.OrdinalIgnoreCase); break;
+                case SplitName.TransVS: shouldSplit = mem.PlayerData<int>(Offset.fireballLevel) == 1 && nextScene != currScene; break;
 
-                case SplitName.KingsPass: shouldSplit = sceneName.StartsWith("Tutorial_01") && nextScene.StartsWith("Town"); break;
-                case SplitName.KingsPassEnterFromTown: shouldSplit = sceneName.StartsWith("Town") && nextScene.StartsWith("Tutorial_01"); break;
-                case SplitName.BlueLake: shouldSplit = !sceneName.StartsWith("Crossroads_50") && nextScene.StartsWith("Crossroads_50"); break;
-                case SplitName.CatacombsEntry: shouldSplit = !sceneName.StartsWith("RestingGrounds_10") && nextScene.StartsWith("RestingGrounds_10"); break;
+                case SplitName.KingsPass: shouldSplit = currScene.StartsWith("Tutorial_01") && nextScene.StartsWith("Town"); break;
+                case SplitName.KingsPassEnterFromTown: shouldSplit = currScene.StartsWith("Town") && nextScene.StartsWith("Tutorial_01"); break;
+                case SplitName.BlueLake: shouldSplit = !currScene.StartsWith("Crossroads_50") && nextScene.StartsWith("Crossroads_50"); break;
+                case SplitName.CatacombsEntry: shouldSplit = !currScene.StartsWith("RestingGrounds_10") && nextScene.StartsWith("RestingGrounds_10"); break;
 
-                case SplitName.EnterNKG: shouldSplit = sceneName.StartsWith("Grimm_Main_Tent") && nextScene.StartsWith("Grimm_Nightmare"); break;
-                case SplitName.EnterGreenpath: shouldSplit = !sceneName.StartsWith("Fungus1_01") && nextScene.StartsWith("Fungus1_01"); break;
+                case SplitName.EnterNKG: shouldSplit = currScene.StartsWith("Grimm_Main_Tent") && nextScene.StartsWith("Grimm_Nightmare"); break;
+                case SplitName.EnterGreenpath: shouldSplit = !currScene.StartsWith("Fungus1_01") && nextScene.StartsWith("Fungus1_01"); break;
                 case SplitName.EnterGreenpathWithOvercharm:
-                    shouldSplit = !sceneName.StartsWith("Fungus1_01")
+                    shouldSplit = !currScene.StartsWith("Fungus1_01")
                         && nextScene.StartsWith("Fungus1_01")
                         && mem.PlayerData<bool>(Offset.canOvercharm);
                     break;
-                case SplitName.EnterSanctum: shouldSplit = !sceneName.StartsWith("Ruins1_23") && nextScene.StartsWith("Ruins1_23"); break;
+                case SplitName.EnterSanctum: shouldSplit = !currScene.StartsWith("Ruins1_23") && nextScene.StartsWith("Ruins1_23"); break;
                 case SplitName.EnterSanctumWithShadeSoul:
-                    shouldSplit = !sceneName.StartsWith("Ruins1_23")
+                    shouldSplit = !currScene.StartsWith("Ruins1_23")
                         && nextScene.StartsWith("Ruins1_23")
                         && mem.PlayerData<int>(Offset.fireballLevel) == 2;
                     break;
-                case SplitName.EnterAnyDream: shouldSplit = nextScene.StartsWith("Dream_") && nextScene != sceneName; break;
-                case SplitName.EnterGodhome: shouldSplit = nextScene.StartsWith("GG_Atrium") && nextScene != sceneName; break;
+                case SplitName.EnterAnyDream: shouldSplit = nextScene.StartsWith("Dream_") && nextScene != currScene; break;
+                case SplitName.EnterGodhome: shouldSplit = nextScene.StartsWith("GG_Atrium") && nextScene != currScene; break;
 
-                case SplitName.EnterJunkPit: shouldSplit = nextScene.Equals("GG_Waterways") && nextScene != sceneName; break;
+                case SplitName.EnterJunkPit: shouldSplit = nextScene.Equals("GG_Waterways") && nextScene != currScene; break;
                 case SplitName.EnterDeepnest:
                     shouldSplit =
                         (nextScene.Equals("Fungus2_25") ||
                         nextScene.Equals("Deepnest_42") ||
                         nextScene.Equals("Abyss_03b") ||
                         nextScene.Equals("Deepnest_01b")) &&
-                        nextScene != sceneName;
+                        nextScene != currScene;
                     break;
-                case SplitName.EnterBeastDen: shouldSplit = nextScene.Equals("Deepnest_Spider_Town") && nextScene != sceneName; break;
-                case SplitName.EnterCrown: shouldSplit = nextScene.Equals("Mines_23") && nextScene != sceneName; break;
-                case SplitName.EnterDirtmouth: shouldSplit = nextScene.Equals("Town") && nextScene != sceneName; break;
-                case SplitName.EnterRafters: shouldSplit = nextScene.Equals("Ruins1_03") && nextScene != sceneName; break;
-                case SplitName.SalubraExit: shouldSplit = sceneName.Equals("Room_Charm_Shop") && nextScene != sceneName; break;
+                case SplitName.EnterBeastDen: shouldSplit = nextScene.Equals("Deepnest_Spider_Town") && nextScene != currScene; break;
+                case SplitName.EnterCrown: shouldSplit = nextScene.Equals("Mines_23") && nextScene != currScene; break;
+                case SplitName.EnterDirtmouth: shouldSplit = nextScene.Equals("Town") && nextScene != currScene; break;
+                case SplitName.EnterRafters: shouldSplit = nextScene.Equals("Ruins1_03") && nextScene != currScene; break;
+                case SplitName.SalubraExit: shouldSplit = currScene.Equals("Room_Charm_Shop") && nextScene != currScene; break;
                 // since Ruins1_18 has both bench and bridge, don't include Ruins1_18 bridge to Ruins2_03b
-                case SplitName.SpireBenchExit: shouldSplit = sceneName.StartsWith("Ruins1_18") && nextScene.StartsWith("Ruins2_01"); break;
+                case SplitName.SpireBenchExit: shouldSplit = currScene.StartsWith("Ruins1_18") && nextScene.StartsWith("Ruins2_01"); break;
 
                 case SplitName.PreGrimmShopTrans:
                     shouldSplit = mem.PlayerData<bool>(Offset.hasLantern)
                         && mem.PlayerData<int>(Offset.maxHealthBase) == 6
                         && (mem.PlayerData<int>(Offset.vesselFragments) == 4 || (mem.PlayerData<int>(Offset.MPReserveMax) == 33 && mem.PlayerData<int>(Offset.vesselFragments) == 2))
-                        && !sceneName.StartsWith("Room_shop");
+                        && !currScene.StartsWith("Room_shop");
                     break;
 
                 case SplitName.WaterwaysEntry:
                     shouldSplit = (nextScene.StartsWith("Waterways_01") // Simple Key manhole entrance
                         || nextScene.StartsWith("Waterways_07") // Right of Spike-tunnel, also where Tram entrance meets the rest
-                        ) && nextScene != sceneName; break;
+                        ) && nextScene != currScene; break;
                 case SplitName.FogCanyonEntry:
                     shouldSplit = (nextScene.StartsWith("Fungus3_01") // West Fog Canyon entrance from Greenpath
                         || nextScene.StartsWith("Fungus3_02") // West Fog Canyon entrance from Queen's Station or QGA
                         || nextScene.StartsWith("Fungus3_24") // West Fog Canyon entrance from Queen's Gardens via Overgrown Mound
                         || nextScene.StartsWith("Fungus3_26") // East Fog Canyon, where the Crossroads acid and Leg Eater acid entrances meet
-                        ) && nextScene != sceneName; break;
+                        ) && nextScene != currScene; break;
                 case SplitName.FungalWastesEntry:
                     shouldSplit = (nextScene.StartsWith("Fungus2_06") // Room outside Leg Eater
                         || nextScene.StartsWith("Fungus2_03") // From Queens' Station
                         || nextScene.StartsWith("Fungus2_23") // Bretta from Waterways
                         || nextScene.StartsWith("Fungus2_20") // Spore Shroom room, from QG (this one's unlikely to come up)
-                        ) && nextScene != sceneName; break;
+                        ) && nextScene != currScene; break;
 
-                case SplitName.CrystalMoundExit: shouldSplit = sceneName.StartsWith("Mines_35") && nextScene != sceneName; break;
-                case SplitName.CrystalPeakEntry: shouldSplit = (nextScene.StartsWith("Mines_02") || nextScene.StartsWith("Mines_10")) && nextScene != sceneName; break;
-                case SplitName.QueensGardensEntry: shouldSplit = (nextScene.StartsWith("Fungus3_34") || nextScene.StartsWith("Deepnest_43")) && nextScene != sceneName; break;
-                case SplitName.BasinEntry: shouldSplit = nextScene.StartsWith("Abyss_04") && nextScene != sceneName; break;
-                case SplitName.HiveEntry: shouldSplit = nextScene.StartsWith("Hive_01") && nextScene != sceneName; break;
-                case SplitName.KingdomsEdgeEntry: shouldSplit = nextScene.StartsWith("Deepnest_East_03") && nextScene != sceneName; break;
+                case SplitName.CrystalMoundExit: shouldSplit = currScene.StartsWith("Mines_35") && nextScene != currScene; break;
+                case SplitName.CrystalPeakEntry: shouldSplit = (nextScene.StartsWith("Mines_02") || nextScene.StartsWith("Mines_10")) && nextScene != currScene; break;
+                case SplitName.QueensGardensEntry: shouldSplit = (nextScene.StartsWith("Fungus3_34") || nextScene.StartsWith("Deepnest_43")) && nextScene != currScene; break;
+                case SplitName.BasinEntry: shouldSplit = nextScene.StartsWith("Abyss_04") && nextScene != currScene; break;
+                case SplitName.HiveEntry: shouldSplit = nextScene.StartsWith("Hive_01") && nextScene != currScene; break;
+                case SplitName.KingdomsEdgeEntry: shouldSplit = nextScene.StartsWith("Deepnest_East_03") && nextScene != currScene; break;
                 case SplitName.KingdomsEdgeOvercharmedEntry:
                     shouldSplit =
                         nextScene.StartsWith("Deepnest_East_03") &&
-                        nextScene != sceneName &&
+                        nextScene != currScene &&
                         mem.PlayerData<bool>(Offset.overcharmed);
                     break;
 
-                case SplitName.GodhomeBench: shouldSplit = sceneName.StartsWith("GG_Spa") && sceneName != nextScene && !store.SplitThisTransition; break;
+                case SplitName.GodhomeBench: shouldSplit = currScene.StartsWith("GG_Spa") && currScene != nextScene && !store.SplitThisTransition; break;
                 case SplitName.GodhomeLoreRoom:
                     shouldSplit =
-                        (sceneName.StartsWith("GG_Engine") || sceneName.StartsWith("GG_Unn") || sceneName.StartsWith("GG_Wyrm"))
-                        && sceneName != nextScene
+                        (currScene.StartsWith("GG_Engine") || currScene.StartsWith("GG_Unn") || currScene.StartsWith("GG_Wyrm"))
+                        && currScene != nextScene
                         && !store.SplitThisTransition;
                     break;
 
-                case SplitName.TransClaw: shouldSplit = mem.PlayerData<bool>(Offset.hasWallJump) && nextScene != sceneName; break;
-                case SplitName.TransGorgeousHusk: shouldSplit = mem.PlayerData<bool>(Offset.killedGorgeousHusk) && nextScene != sceneName; break;
-                case SplitName.TransDescendingDark: shouldSplit = mem.PlayerData<int>(Offset.quakeLevel) == 2 && nextScene != sceneName; break;
-                case SplitName.TransTear: shouldSplit = mem.PlayerData<bool>(Offset.hasAcidArmour) && nextScene != sceneName; break;
+                case SplitName.TransClaw: shouldSplit = mem.PlayerData<bool>(Offset.hasWallJump) && nextScene != currScene; break;
+                case SplitName.TransGorgeousHusk: shouldSplit = mem.PlayerData<bool>(Offset.killedGorgeousHusk) && nextScene != currScene; break;
+                case SplitName.TransDescendingDark: shouldSplit = mem.PlayerData<int>(Offset.quakeLevel) == 2 && nextScene != currScene; break;
+                case SplitName.TransTear: shouldSplit = mem.PlayerData<bool>(Offset.hasAcidArmour) && nextScene != currScene; break;
                 case SplitName.TransTearWithGrub:
                     shouldSplit =
                         mem.PlayerData<bool>(Offset.hasAcidArmour) &&
                         mem.PlayerDataStringList(Offset.scenesGrubRescued).Contains("Waterways_13") &&
 
-                        nextScene != sceneName; break;
-                case SplitName.TransShadeSoul: shouldSplit = mem.PlayerData<int>(Offset.fireballLevel) == 2 && nextScene != sceneName; break;
+                        nextScene != currScene; break;
+                case SplitName.TransShadeSoul: shouldSplit = mem.PlayerData<int>(Offset.fireballLevel) == 2 && nextScene != currScene; break;
 
-                case SplitName.AnyTransition: shouldSplit = shouldSplitTransition(nextScene, sceneName); break;
+                case SplitName.AnyTransition: shouldSplit = shouldSplitTransition(nextScene, currScene); break;
                 case SplitName.TransitionAfterSaveState:
-                    if (shouldSplitTransition(nextScene, sceneName)) {
-                        shouldSplit = !(debugSaveStateSceneNames.Contains(nextScene) || debugSaveStateSceneNames.Contains(sceneName));
+                    if (shouldSplitTransition(nextScene, currScene)) {
+                        shouldSplit = !(debugSaveStateSceneNames.Contains(nextScene) || debugSaveStateSceneNames.Contains(currScene));
                     }
                     break;
 
-                case SplitName.QueensGardensPostArenaTransition: shouldSplit = nextScene.StartsWith("Fungus3_13") && nextScene != sceneName; break;
-                case SplitName.QueensGardensFrogsTrans: shouldSplit = nextScene.StartsWith("Fungus1_23") && nextScene != sceneName; break;
-                case SplitName.Pantheon1to4Entry: shouldSplit = nextScene.StartsWith("GG_Boss_Door_Entrance") && nextScene != sceneName; break;
-                case SplitName.Pantheon5Entry: shouldSplit = nextScene.StartsWith("GG_Vengefly_V") && nextScene != sceneName; break;
+                case SplitName.QueensGardensPostArenaTransition: shouldSplit = nextScene.StartsWith("Fungus3_13") && nextScene != currScene; break;
+                case SplitName.QueensGardensFrogsTrans: shouldSplit = nextScene.StartsWith("Fungus1_23") && nextScene != currScene; break;
+                case SplitName.Pantheon1to4Entry: shouldSplit = nextScene.StartsWith("GG_Boss_Door_Entrance") && nextScene != currScene; break;
+                case SplitName.Pantheon5Entry: shouldSplit = nextScene.StartsWith("GG_Vengefly_V") && nextScene != currScene; break;
 
-                case SplitName.EnterHornet1: shouldSplit = nextScene.StartsWith("Fungus1_04") && nextScene != sceneName; break;
-                case SplitName.EnterSoulMaster: shouldSplit = nextScene.StartsWith("Ruins1_24") && nextScene != sceneName; break;
-                case SplitName.EnterHiveKnight: shouldSplit = nextScene.StartsWith("Hive_05") && nextScene != sceneName; break;
-                case SplitName.EnterHornet2: shouldSplit = nextScene.StartsWith("Deepnest_East_Hornet") && nextScene != sceneName; break;
-                case SplitName.EnterBroodingMawlek: shouldSplit = nextScene.StartsWith("Crossroads_09") && nextScene != sceneName; break;
-                case SplitName.EnterNosk: shouldSplit = nextScene.StartsWith("Deepnest_32") && nextScene != sceneName; break;
+                case SplitName.EnterHornet1: shouldSplit = nextScene.StartsWith("Fungus1_04") && nextScene != currScene; break;
+                case SplitName.EnterSoulMaster: shouldSplit = nextScene.StartsWith("Ruins1_24") && nextScene != currScene; break;
+                case SplitName.EnterHiveKnight: shouldSplit = nextScene.StartsWith("Hive_05") && nextScene != currScene; break;
+                case SplitName.EnterHornet2: shouldSplit = nextScene.StartsWith("Deepnest_East_Hornet") && nextScene != currScene; break;
+                case SplitName.EnterBroodingMawlek: shouldSplit = nextScene.StartsWith("Crossroads_09") && nextScene != currScene; break;
+                case SplitName.EnterNosk: shouldSplit = nextScene.StartsWith("Deepnest_32") && nextScene != currScene; break;
                 case SplitName.EnterTMG:
-                    shouldSplit = nextScene.StartsWith("Grimm_Main_Tent") && nextScene != sceneName
+                    shouldSplit = nextScene.StartsWith("Grimm_Main_Tent") && nextScene != currScene
                     && mem.PlayerData<int>(Offset.grimmChildLevel) == 2
                     && mem.PlayerData<int>(Offset.flamesCollected) == 3; break;
-                case SplitName.EnterLoveTower: shouldSplit = nextScene.StartsWith("Ruins2_11") && nextScene != sceneName; break;
+                case SplitName.EnterLoveTower: shouldSplit = nextScene.StartsWith("Ruins2_11") && nextScene != currScene; break;
 
-                case SplitName.VengeflyKingTrans: shouldSplit = mem.PlayerData<bool>(Offset.zoteRescuedBuzzer) && nextScene != sceneName; break;
-                case SplitName.MegaMossChargerTrans: shouldSplit = mem.PlayerData<bool>(Offset.megaMossChargerDefeated) && nextScene != sceneName; break;
-                case SplitName.ElderHuTrans: shouldSplit = mem.PlayerData<bool>(Offset.killedGhostHu) && nextScene != sceneName; break;
-                case SplitName.BlackKnightTrans: shouldSplit = mem.PlayerData<bool>(Offset.killedBlackKnight) && nextScene != sceneName; break;
+                case SplitName.VengeflyKingTrans: shouldSplit = mem.PlayerData<bool>(Offset.zoteRescuedBuzzer) && nextScene != currScene; break;
+                case SplitName.MegaMossChargerTrans: shouldSplit = mem.PlayerData<bool>(Offset.megaMossChargerDefeated) && nextScene != currScene; break;
+                case SplitName.ElderHuTrans: shouldSplit = mem.PlayerData<bool>(Offset.killedGhostHu) && nextScene != currScene; break;
+                case SplitName.BlackKnightTrans: shouldSplit = mem.PlayerData<bool>(Offset.killedBlackKnight) && nextScene != currScene; break;
                 case SplitName.BrokenVesselTrans:
                     shouldSplit =
                         mem.PlayerData<bool>(Offset.killedInfectedKnight) &&
                         mem.PlayerData<int>(Offset.health) > 0 &&
-                        nextScene != sceneName;
+                        nextScene != currScene;
                     break;
 
-                case SplitName.LumaflyLanternTransition: shouldSplit = mem.PlayerData<bool>(Offset.hasLantern) && !sceneName.StartsWith("Room_shop"); break;
+                case SplitName.LumaflyLanternTransition: shouldSplit = mem.PlayerData<bool>(Offset.hasLantern) && !currScene.StartsWith("Room_shop"); break;
 
                 // White palace and path of pain transition splits are in the White Palace & Path of Pain #region
 

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -559,15 +559,158 @@ namespace LiveSplit.HollowKnight {
 
                 #endregion Items
 
+                #region Transitions
+
+                // these aren't really sorted, there's so many and my brain can only handle so much split sorting, maybe next update
+
+                case SplitName.AncestralMound: shouldSplit = nextScene.Equals("Crossroads_ShamanTemple") && nextScene != sceneName; break;
+                case SplitName.TransCollector: shouldSplit = mem.PlayerData<bool>(Offset.collectorDefeated) && sceneName.StartsWith("Ruins2_11") && nextScene != sceneName; break;
+                case SplitName.TeachersArchive: shouldSplit = sceneName.Equals("Fungus3_archive", StringComparison.OrdinalIgnoreCase); break;
+                case SplitName.TransVS: shouldSplit = mem.PlayerData<int>(Offset.fireballLevel) == 1 && nextScene != sceneName; break;
+
+                case SplitName.KingsPass: shouldSplit = sceneName.StartsWith("Tutorial_01") && nextScene.StartsWith("Town"); break;
+                case SplitName.KingsPassEnterFromTown: shouldSplit = sceneName.StartsWith("Town") && nextScene.StartsWith("Tutorial_01"); break;
+                case SplitName.BlueLake: shouldSplit = !sceneName.StartsWith("Crossroads_50") && nextScene.StartsWith("Crossroads_50"); break;
+                case SplitName.CatacombsEntry: shouldSplit = !sceneName.StartsWith("RestingGrounds_10") && nextScene.StartsWith("RestingGrounds_10"); break;
+
+                case SplitName.EnterNKG: shouldSplit = sceneName.StartsWith("Grimm_Main_Tent") && nextScene.StartsWith("Grimm_Nightmare"); break;
+                case SplitName.EnterGreenpath: shouldSplit = !sceneName.StartsWith("Fungus1_01") && nextScene.StartsWith("Fungus1_01"); break;
+                case SplitName.EnterGreenpathWithOvercharm:
+                    shouldSplit = !sceneName.StartsWith("Fungus1_01")
+                        && nextScene.StartsWith("Fungus1_01")
+                        && mem.PlayerData<bool>(Offset.canOvercharm);
+                    break;
+                case SplitName.EnterSanctum: shouldSplit = !sceneName.StartsWith("Ruins1_23") && nextScene.StartsWith("Ruins1_23"); break;
+                case SplitName.EnterSanctumWithShadeSoul:
+                    shouldSplit = !sceneName.StartsWith("Ruins1_23")
+                        && nextScene.StartsWith("Ruins1_23")
+                        && mem.PlayerData<int>(Offset.fireballLevel) == 2;
+                    break;
+                case SplitName.EnterAnyDream: shouldSplit = nextScene.StartsWith("Dream_") && nextScene != sceneName; break;
+                case SplitName.EnterGodhome: shouldSplit = nextScene.StartsWith("GG_Atrium") && nextScene != sceneName; break;
+
+                case SplitName.EnterJunkPit: shouldSplit = nextScene.Equals("GG_Waterways") && nextScene != sceneName; break;
+                case SplitName.EnterDeepnest:
+                    shouldSplit =
+                        (nextScene.Equals("Fungus2_25") ||
+                        nextScene.Equals("Deepnest_42") ||
+                        nextScene.Equals("Abyss_03b") ||
+                        nextScene.Equals("Deepnest_01b")) &&
+                        nextScene != sceneName;
+                    break;
+                case SplitName.EnterBeastDen: shouldSplit = nextScene.Equals("Deepnest_Spider_Town") && nextScene != sceneName; break;
+                case SplitName.EnterCrown: shouldSplit = nextScene.Equals("Mines_23") && nextScene != sceneName; break;
+                case SplitName.EnterDirtmouth: shouldSplit = nextScene.Equals("Town") && nextScene != sceneName; break;
+                case SplitName.EnterRafters: shouldSplit = nextScene.Equals("Ruins1_03") && nextScene != sceneName; break;
+                case SplitName.SalubraExit: shouldSplit = sceneName.Equals("Room_Charm_Shop") && nextScene != sceneName; break;
+                // since Ruins1_18 has both bench and bridge, don't include Ruins1_18 bridge to Ruins2_03b
+                case SplitName.SpireBenchExit: shouldSplit = sceneName.StartsWith("Ruins1_18") && nextScene.StartsWith("Ruins2_01"); break;
+
+                case SplitName.PreGrimmShopTrans:
+                    shouldSplit = mem.PlayerData<bool>(Offset.hasLantern)
+                        && mem.PlayerData<int>(Offset.maxHealthBase) == 6
+                        && (mem.PlayerData<int>(Offset.vesselFragments) == 4 || (mem.PlayerData<int>(Offset.MPReserveMax) == 33 && mem.PlayerData<int>(Offset.vesselFragments) == 2))
+                        && !sceneName.StartsWith("Room_shop");
+                    break;
+
+                case SplitName.WaterwaysEntry:
+                    shouldSplit = (nextScene.StartsWith("Waterways_01") // Simple Key manhole entrance
+                        || nextScene.StartsWith("Waterways_07") // Right of Spike-tunnel, also where Tram entrance meets the rest
+                        ) && nextScene != sceneName; break;
+                case SplitName.FogCanyonEntry:
+                    shouldSplit = (nextScene.StartsWith("Fungus3_01") // West Fog Canyon entrance from Greenpath
+                        || nextScene.StartsWith("Fungus3_02") // West Fog Canyon entrance from Queen's Station or QGA
+                        || nextScene.StartsWith("Fungus3_24") // West Fog Canyon entrance from Queen's Gardens via Overgrown Mound
+                        || nextScene.StartsWith("Fungus3_26") // East Fog Canyon, where the Crossroads acid and Leg Eater acid entrances meet
+                        ) && nextScene != sceneName; break;
+                case SplitName.FungalWastesEntry:
+                    shouldSplit = (nextScene.StartsWith("Fungus2_06") // Room outside Leg Eater
+                        || nextScene.StartsWith("Fungus2_03") // From Queens' Station
+                        || nextScene.StartsWith("Fungus2_23") // Bretta from Waterways
+                        || nextScene.StartsWith("Fungus2_20") // Spore Shroom room, from QG (this one's unlikely to come up)
+                        ) && nextScene != sceneName; break;
+
+                case SplitName.CrystalMoundExit: shouldSplit = sceneName.StartsWith("Mines_35") && nextScene != sceneName; break;
+                case SplitName.CrystalPeakEntry: shouldSplit = (nextScene.StartsWith("Mines_02") || nextScene.StartsWith("Mines_10")) && nextScene != sceneName; break;
+                case SplitName.QueensGardensEntry: shouldSplit = (nextScene.StartsWith("Fungus3_34") || nextScene.StartsWith("Deepnest_43")) && nextScene != sceneName; break;
+                case SplitName.BasinEntry: shouldSplit = nextScene.StartsWith("Abyss_04") && nextScene != sceneName; break;
+                case SplitName.HiveEntry: shouldSplit = nextScene.StartsWith("Hive_01") && nextScene != sceneName; break;
+                case SplitName.KingdomsEdgeEntry: shouldSplit = nextScene.StartsWith("Deepnest_East_03") && nextScene != sceneName; break;
+                case SplitName.KingdomsEdgeOvercharmedEntry:
+                    shouldSplit =
+                        nextScene.StartsWith("Deepnest_East_03") &&
+                        nextScene != sceneName &&
+                        mem.PlayerData<bool>(Offset.overcharmed);
+                    break;
+
+                case SplitName.GodhomeBench: shouldSplit = sceneName.StartsWith("GG_Spa") && sceneName != nextScene && !store.SplitThisTransition; break;
+                case SplitName.GodhomeLoreRoom:
+                    shouldSplit =
+                        (sceneName.StartsWith("GG_Engine") || sceneName.StartsWith("GG_Unn") || sceneName.StartsWith("GG_Wyrm"))
+                        && sceneName != nextScene
+                        && !store.SplitThisTransition;
+                    break;
+
+                case SplitName.TransClaw: shouldSplit = mem.PlayerData<bool>(Offset.hasWallJump) && nextScene != sceneName; break;
+                case SplitName.TransGorgeousHusk: shouldSplit = mem.PlayerData<bool>(Offset.killedGorgeousHusk) && nextScene != sceneName; break;
+                case SplitName.TransDescendingDark: shouldSplit = mem.PlayerData<int>(Offset.quakeLevel) == 2 && nextScene != sceneName; break;
+                case SplitName.TransTear: shouldSplit = mem.PlayerData<bool>(Offset.hasAcidArmour) && nextScene != sceneName; break;
+                case SplitName.TransTearWithGrub:
+                    shouldSplit =
+                        mem.PlayerData<bool>(Offset.hasAcidArmour) &&
+                        mem.PlayerDataStringList(Offset.scenesGrubRescued).Contains("Waterways_13") &&
+
+                        nextScene != sceneName; break;
+                case SplitName.TransShadeSoul: shouldSplit = mem.PlayerData<int>(Offset.fireballLevel) == 2 && nextScene != sceneName; break;
+
+                case SplitName.AnyTransition: shouldSplit = shouldSplitTransition(nextScene, sceneName); break;
+                case SplitName.TransitionAfterSaveState:
+                    if (shouldSplitTransition(nextScene, sceneName)) {
+                        shouldSplit = !(debugSaveStateSceneNames.Contains(nextScene) || debugSaveStateSceneNames.Contains(sceneName));
+                    }
+                    break;
+
+                case SplitName.QueensGardensPostArenaTransition: shouldSplit = nextScene.StartsWith("Fungus3_13") && nextScene != sceneName; break;
+                case SplitName.QueensGardensFrogsTrans: shouldSplit = nextScene.StartsWith("Fungus1_23") && nextScene != sceneName; break;
+                case SplitName.Pantheon1to4Entry: shouldSplit = nextScene.StartsWith("GG_Boss_Door_Entrance") && nextScene != sceneName; break;
+                case SplitName.Pantheon5Entry: shouldSplit = nextScene.StartsWith("GG_Vengefly_V") && nextScene != sceneName; break;
+
+                case SplitName.EnterHornet1: shouldSplit = nextScene.StartsWith("Fungus1_04") && nextScene != sceneName; break;
+                case SplitName.EnterSoulMaster: shouldSplit = nextScene.StartsWith("Ruins1_24") && nextScene != sceneName; break;
+                case SplitName.EnterHiveKnight: shouldSplit = nextScene.StartsWith("Hive_05") && nextScene != sceneName; break;
+                case SplitName.EnterHornet2: shouldSplit = nextScene.StartsWith("Deepnest_East_Hornet") && nextScene != sceneName; break;
+                case SplitName.EnterBroodingMawlek: shouldSplit = nextScene.StartsWith("Crossroads_09") && nextScene != sceneName; break;
+                case SplitName.EnterNosk: shouldSplit = nextScene.StartsWith("Deepnest_32") && nextScene != sceneName; break;
+                case SplitName.EnterTMG:
+                    shouldSplit = nextScene.StartsWith("Grimm_Main_Tent") && nextScene != sceneName
+                    && mem.PlayerData<int>(Offset.grimmChildLevel) == 2
+                    && mem.PlayerData<int>(Offset.flamesCollected) == 3; break;
+                case SplitName.EnterLoveTower: shouldSplit = nextScene.StartsWith("Ruins2_11") && nextScene != sceneName; break;
+
+                case SplitName.VengeflyKingTrans: shouldSplit = mem.PlayerData<bool>(Offset.zoteRescuedBuzzer) && nextScene != sceneName; break;
+                case SplitName.MegaMossChargerTrans: shouldSplit = mem.PlayerData<bool>(Offset.megaMossChargerDefeated) && nextScene != sceneName; break;
+                case SplitName.ElderHuTrans: shouldSplit = mem.PlayerData<bool>(Offset.killedGhostHu) && nextScene != sceneName; break;
+                case SplitName.BlackKnightTrans: shouldSplit = mem.PlayerData<bool>(Offset.killedBlackKnight) && nextScene != sceneName; break;
+                case SplitName.BrokenVesselTrans:
+                    shouldSplit =
+                        mem.PlayerData<bool>(Offset.killedInfectedKnight) &&
+                        mem.PlayerData<int>(Offset.health) > 0 &&
+                        nextScene != sceneName;
+                    break;
+
+                case SplitName.LumaflyLanternTransition: shouldSplit = mem.PlayerData<bool>(Offset.hasLantern) && !sceneName.StartsWith("Room_shop"); break;
+
+                // White palace and path of pain transition splits are in the White Palace & Path of Pain #region
+
+                #endregion Transitions
+
                 case SplitName.Abyss: shouldSplit = mem.PlayerData<bool>(Offset.visitedAbyss); break;
                 case SplitName.Aluba: shouldSplit = mem.PlayerData<bool>(Offset.killedLazyFlyer); break;
-                case SplitName.AncestralMound: shouldSplit = nextScene.Equals("Crossroads_ShamanTemple") && nextScene != sceneName; break;
                 case SplitName.AspidHunter: shouldSplit = mem.PlayerData<int>(Offset.killsSpitter) == 17; break;
                 case SplitName.BeastsDenTrapBench: shouldSplit = mem.PlayerData<bool>(Offset.spiderCapture); break;
                 case SplitName.BrettaRescued: shouldSplit = mem.PlayerData<bool>(Offset.brettaRescued); break;
                 case SplitName.BrummFlame: shouldSplit = mem.PlayerData<bool>(Offset.gotBrummsFlame); break;
                 case SplitName.CityOfTears: shouldSplit = mem.PlayerData<bool>(Offset.visitedRuins); break;
-                case SplitName.TransCollector: shouldSplit = mem.PlayerData<bool>(Offset.collectorDefeated) && sceneName.StartsWith("Ruins2_11") && nextScene != sceneName; break;
                 case SplitName.Colosseum: shouldSplit = mem.PlayerData<bool>(Offset.seenColosseumTitle); break;
                 case SplitName.ColosseumBronze: shouldSplit = mem.PlayerData<bool>(Offset.colosseumBronzeCompleted); break;
                 case SplitName.ColosseumGold: shouldSplit = mem.PlayerData<bool>(Offset.colosseumGoldCompleted); break;
@@ -657,9 +800,7 @@ namespace LiveSplit.HollowKnight {
                                                               && mem.PlayerData<bool>(Offset.travelling)
                                                               && mem.PlayerData<bool>(Offset.openedStagNest); break;
                 case SplitName.StoreroomsStation: shouldSplit = mem.PlayerData<bool>(Offset.openedRuins1); break;
-                case SplitName.TeachersArchive: shouldSplit = sceneName.Equals("Fungus3_archive", StringComparison.OrdinalIgnoreCase); break;
                 case SplitName.UnchainedHollowKnight: shouldSplit = mem.PlayerData<bool>(Offset.unchainedHollowKnight); break;
-                case SplitName.TransVS: shouldSplit = mem.PlayerData<int>(Offset.fireballLevel) == 1 && nextScene != sceneName; break;
                 case SplitName.VesselFragment1: shouldSplit = mem.PlayerData<int>(Offset.MPReserveMax) == 0 && mem.PlayerData<int>(Offset.vesselFragments) == 1; break;
                 case SplitName.VesselFragment2: shouldSplit = mem.PlayerData<int>(Offset.MPReserveMax) == 0 && mem.PlayerData<int>(Offset.vesselFragments) == 2; break;
                 case SplitName.Vessel1: shouldSplit = mem.PlayerData<int>(Offset.MPReserveMax) == 33; break;
@@ -844,11 +985,6 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.Essence2300: shouldSplit = mem.PlayerData<int>(Offset.dreamOrbs) >= 2300; break;
                 case SplitName.Essence2400: shouldSplit = mem.PlayerData<int>(Offset.dreamOrbs) >= 2400; break;
 
-                case SplitName.KingsPass: shouldSplit = sceneName.StartsWith("Tutorial_01") && nextScene.StartsWith("Town"); break;
-                case SplitName.KingsPassEnterFromTown: shouldSplit = sceneName.StartsWith("Town") && nextScene.StartsWith("Tutorial_01"); break;
-                case SplitName.BlueLake: shouldSplit = !sceneName.StartsWith("Crossroads_50") && nextScene.StartsWith("Crossroads_50"); break;
-                case SplitName.CatacombsEntry: shouldSplit = !sceneName.StartsWith("RestingGrounds_10") && nextScene.StartsWith("RestingGrounds_10"); break;
-
                 case SplitName.VengeflyKingP: shouldSplit = sceneName.StartsWith("GG_Vengefly") && nextScene.StartsWith("GG_Gruz_Mother"); break;
                 case SplitName.GruzMotherP: shouldSplit = sceneName.StartsWith("GG_Gruz_Mother") && nextScene.StartsWith("GG_False_Knight"); break;
                 case SplitName.FalseKnightP: shouldSplit = sceneName.StartsWith("GG_False_Knight") && nextScene.StartsWith("GG_Mega_Moss_Charger"); break;
@@ -1017,43 +1153,12 @@ namespace LiveSplit.HollowKnight {
 
                 case SplitName.killedSoulTwister: shouldSplit = mem.PlayerData<bool>(Offset.killedMage); break;
 
-                case SplitName.EnterNKG: shouldSplit = sceneName.StartsWith("Grimm_Main_Tent") && nextScene.StartsWith("Grimm_Nightmare"); break;
-                case SplitName.EnterGreenpath: shouldSplit = !sceneName.StartsWith("Fungus1_01") && nextScene.StartsWith("Fungus1_01"); break;
-                case SplitName.EnterGreenpathWithOvercharm:
-                    shouldSplit = !sceneName.StartsWith("Fungus1_01")
-                        && nextScene.StartsWith("Fungus1_01")
-                        && mem.PlayerData<bool>(Offset.canOvercharm);
-                    break;
-                case SplitName.EnterSanctum: shouldSplit = !sceneName.StartsWith("Ruins1_23") && nextScene.StartsWith("Ruins1_23"); break;
-                case SplitName.EnterSanctumWithShadeSoul:
-                    shouldSplit = !sceneName.StartsWith("Ruins1_23")
-                        && nextScene.StartsWith("Ruins1_23")
-                        && mem.PlayerData<int>(Offset.fireballLevel) == 2;
-                    break;
-                case SplitName.EnterAnyDream: shouldSplit = nextScene.StartsWith("Dream_") && nextScene != sceneName; break;
-                case SplitName.EnterGodhome: shouldSplit = nextScene.StartsWith("GG_Atrium") && nextScene != sceneName; break;
                 case SplitName.DgateKingdomsEdgeAcid:
                     shouldSplit =
                         mem.PlayerDataString<string>(Offset.dreamGateScene).StartsWith("Deepnest_East_04") &&
                         (mem.PlayerData<float>(Offset.dreamGateX) > 27.0f && mem.PlayerData<float>(Offset.dreamGateX) < 29f) &&
                         (mem.PlayerData<float>(Offset.dreamGateY) > 7.0f && mem.PlayerData<float>(Offset.dreamGateY) < 9f);
                     break;
-                case SplitName.EnterJunkPit: shouldSplit = nextScene.Equals("GG_Waterways") && nextScene != sceneName; break;
-                case SplitName.EnterDeepnest:
-                    shouldSplit = 
-                        (nextScene.Equals("Fungus2_25") ||
-                        nextScene.Equals("Deepnest_42") ||
-                        nextScene.Equals("Abyss_03b") ||
-                        nextScene.Equals("Deepnest_01b")) &&
-                        nextScene != sceneName;
-                    break;
-                case SplitName.EnterBeastDen: shouldSplit = nextScene.Equals("Deepnest_Spider_Town") && nextScene != sceneName; break;
-                case SplitName.EnterCrown: shouldSplit = nextScene.Equals("Mines_23") && nextScene != sceneName; break;
-                case SplitName.EnterDirtmouth: shouldSplit = nextScene.Equals("Town") && nextScene != sceneName; break;
-                case SplitName.EnterRafters: shouldSplit = nextScene.Equals("Ruins1_03") && nextScene != sceneName; break;
-                case SplitName.SalubraExit: shouldSplit = sceneName.Equals("Room_Charm_Shop") && nextScene != sceneName; break;
-                // since Ruins1_18 has both bench and bridge, don't include Ruins1_18 bridge to Ruins2_03b
-                case SplitName.SpireBenchExit: shouldSplit = sceneName.StartsWith("Ruins1_18") && nextScene.StartsWith("Ruins2_01"); break;
 
                 case SplitName.FailedChampionEssence: shouldSplit = mem.PlayerData<bool>(Offset.falseKnightOrbsCollected); break;
                 case SplitName.SoulTyrantEssence: shouldSplit = mem.PlayerData<bool>(Offset.mageLordOrbsCollected); break;
@@ -1066,12 +1171,6 @@ namespace LiveSplit.HollowKnight {
                         && mem.PlayerData<int>(Offset.maxHealthBase) == 6
                         && (mem.PlayerData<int>(Offset.vesselFragments) == 4 || (mem.PlayerData<int>(Offset.MPReserveMax) == 33 && mem.PlayerData<int>(Offset.vesselFragments) == 2));
                     break;
-                case SplitName.PreGrimmShopTrans:
-                    shouldSplit = mem.PlayerData<bool>(Offset.hasLantern)
-                        && mem.PlayerData<int>(Offset.maxHealthBase) == 6
-                        && (mem.PlayerData<int>(Offset.vesselFragments) == 4 || (mem.PlayerData<int>(Offset.MPReserveMax) == 33 && mem.PlayerData<int>(Offset.vesselFragments) == 2))
-                        && !sceneName.StartsWith("Room_shop");
-                    break;
                 case SplitName.ElderHuEssence: shouldSplit = mem.PlayerData<int>(Offset.elderHuDefeated) == 2; break;
                 case SplitName.GalienEssence: shouldSplit = mem.PlayerData<int>(Offset.galienDefeated) == 2; break;
                 case SplitName.GorbEssence: shouldSplit = mem.PlayerData<int>(Offset.aladarSlugDefeated) == 2; break;
@@ -1080,35 +1179,6 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.XeroEssence: shouldSplit = mem.PlayerData<int>(Offset.xeroDefeated) == 2; break;
                 case SplitName.MarkothEssence: shouldSplit = mem.PlayerData<int>(Offset.markothDefeated) == 2; break;
 
-                case SplitName.WaterwaysEntry:
-                    shouldSplit = (nextScene.StartsWith("Waterways_01") // Simple Key manhole entrance
-                        || nextScene.StartsWith("Waterways_07") // Right of Spike-tunnel, also where Tram entrance meets the rest
-                        ) && nextScene != sceneName; break;
-                case SplitName.FogCanyonEntry:
-                    shouldSplit = (nextScene.StartsWith("Fungus3_01") // West Fog Canyon entrance from Greenpath
-                        || nextScene.StartsWith("Fungus3_02") // West Fog Canyon entrance from Queen's Station or QGA
-                        || nextScene.StartsWith("Fungus3_24") // West Fog Canyon entrance from Queen's Gardens via Overgrown Mound
-                        || nextScene.StartsWith("Fungus3_26") // East Fog Canyon, where the Crossroads acid and Leg Eater acid entrances meet
-                        ) && nextScene != sceneName; break;
-                case SplitName.FungalWastesEntry:
-                    shouldSplit = (nextScene.StartsWith("Fungus2_06") // Room outside Leg Eater
-                        || nextScene.StartsWith("Fungus2_03") // From Queens' Station
-                        || nextScene.StartsWith("Fungus2_23") // Bretta from Waterways
-                        || nextScene.StartsWith("Fungus2_20") // Spore Shroom room, from QG (this one's unlikely to come up)
-                        ) && nextScene != sceneName; break;
-
-                case SplitName.CrystalMoundExit: shouldSplit = sceneName.StartsWith("Mines_35") && nextScene != sceneName; break;
-                case SplitName.CrystalPeakEntry: shouldSplit = (nextScene.StartsWith("Mines_02") || nextScene.StartsWith("Mines_10")) && nextScene != sceneName; break;
-                case SplitName.QueensGardensEntry: shouldSplit = (nextScene.StartsWith("Fungus3_34") || nextScene.StartsWith("Deepnest_43")) && nextScene != sceneName; break;
-                case SplitName.BasinEntry: shouldSplit = nextScene.StartsWith("Abyss_04") && nextScene != sceneName; break;
-                case SplitName.HiveEntry: shouldSplit = nextScene.StartsWith("Hive_01") && nextScene != sceneName; break;
-                case SplitName.KingdomsEdgeEntry: shouldSplit = nextScene.StartsWith("Deepnest_East_03") && nextScene != sceneName; break;
-                case SplitName.KingdomsEdgeOvercharmedEntry:
-                    shouldSplit =
-                        nextScene.StartsWith("Deepnest_East_03") &&
-                        nextScene != sceneName &&
-                        mem.PlayerData<bool>(Offset.overcharmed);
-                    break;
                 case SplitName.AllCharmNotchesLemm2CP:
                     shouldSplit =
                         mem.PlayerData<int>(Offset.soldTrinket1) == 1 &&
@@ -1125,29 +1195,11 @@ namespace LiveSplit.HollowKnight {
                         && (mem.GetCameraTarget().X < 29.5);
                     break;
                     
-                case SplitName.GodhomeBench: shouldSplit = sceneName.StartsWith("GG_Spa") && sceneName != nextScene && !store.SplitThisTransition; break;
-                case SplitName.GodhomeLoreRoom:
-                    shouldSplit =
-                        (sceneName.StartsWith("GG_Engine") || sceneName.StartsWith("GG_Unn") || sceneName.StartsWith("GG_Wyrm"))
-                        && sceneName != nextScene
-                        && !store.SplitThisTransition;
-                    break;
                 case SplitName.Menu: shouldSplit = sceneName == "Menu_Title"; break;
                 case SplitName.MenuClaw: shouldSplit = mem.PlayerData<bool>(Offset.hasWallJump); break;
                 case SplitName.MenuGorgeousHusk: shouldSplit = mem.PlayerData<bool>(Offset.killedGorgeousHusk); break;
                 case SplitName.MenuIsmasTear: shouldSplit = mem.PlayerData<bool>(Offset.hasAcidArmour); break;
                 case SplitName.MenuShadeSoul: shouldSplit = mem.PlayerData<int>(Offset.fireballLevel) == 2; break;
-                case SplitName.TransClaw: shouldSplit = mem.PlayerData<bool>(Offset.hasWallJump) && nextScene != sceneName; break;
-                case SplitName.TransGorgeousHusk: shouldSplit = mem.PlayerData<bool>(Offset.killedGorgeousHusk) && nextScene != sceneName; break;
-                case SplitName.TransDescendingDark: shouldSplit = mem.PlayerData<int>(Offset.quakeLevel) == 2 && nextScene != sceneName; break;
-                case SplitName.TransTear: shouldSplit = mem.PlayerData<bool>(Offset.hasAcidArmour) && nextScene != sceneName; break;
-                case SplitName.TransTearWithGrub:
-                    shouldSplit =
-                        mem.PlayerData<bool>(Offset.hasAcidArmour) &&
-                        mem.PlayerDataStringList(Offset.scenesGrubRescued).Contains("Waterways_13") &&
-
-                        nextScene != sceneName; break;
-                case SplitName.TransShadeSoul: shouldSplit = mem.PlayerData<int>(Offset.fireballLevel) == 2 && nextScene != sceneName; break;
                 case SplitName.PlayerDeath: shouldSplit = mem.PlayerData<int>(Offset.health) == 0; break;
                 case SplitName.ShadeKilled: shouldSplit = store.CheckToggledFalse(Offset.soulLimited); break;
                 case SplitName.SlyShopFinished:
@@ -1189,22 +1241,12 @@ namespace LiveSplit.HollowKnight {
 
                 case SplitName.WhitePalaceEntry: shouldSplit = nextScene.StartsWith("White_Palace_11") && nextScene != sceneName; break;
                 case SplitName.ManualSplit: shouldSplit = false; break;
-                case SplitName.AnyTransition: shouldSplit = shouldSplitTransition(nextScene, sceneName); break;
-                case SplitName.TransitionAfterSaveState:
-                    if (shouldSplitTransition(nextScene, sceneName)) {
-                        shouldSplit = !(debugSaveStateSceneNames.Contains(nextScene) || debugSaveStateSceneNames.Contains(sceneName));
-                    }
-                    break;
                 case SplitName.OnGhostCoinsIncremented:
                     shouldSplit = store.CheckIncremented(Offset.ghostCoins);
                     break;
                 case SplitName.RidingStag: shouldSplit = store.CheckToggledTrue(Offset.travelling); break;
                 case SplitName.WhitePalaceLowerEntry: shouldSplit = nextScene.StartsWith("White_Palace_01") && nextScene != sceneName; break;
                 case SplitName.WhitePalaceLowerOrb: shouldSplit = nextScene.StartsWith("White_Palace_02") && nextScene != sceneName; break;
-                case SplitName.QueensGardensPostArenaTransition: shouldSplit = nextScene.StartsWith("Fungus3_13") && nextScene != sceneName; break;
-                case SplitName.QueensGardensFrogsTrans: shouldSplit = nextScene.StartsWith("Fungus1_23") && nextScene != sceneName; break;
-                case SplitName.Pantheon1to4Entry: shouldSplit = nextScene.StartsWith("GG_Boss_Door_Entrance") && nextScene != sceneName; break;
-                case SplitName.Pantheon5Entry: shouldSplit = nextScene.StartsWith("GG_Vengefly_V") && nextScene != sceneName; break;
 
                 case SplitName.OnObtainGhostMarissa:
                     shouldSplit = store.CheckIncremented(Offset.dreamOrbs) && sceneName == "Ruins_Bathhouse";
@@ -1280,31 +1322,8 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.ColosseumGoldExit: shouldSplit = mem.PlayerData<bool>(Offset.colosseumGoldCompleted) && !nextScene.StartsWith("Room_Colosseum_Gold") && nextScene != sceneName; break;
                 case SplitName.SoulTyrantEssenceWithSanctumGrub: shouldSplit = mem.PlayerData<bool>(Offset.mageLordOrbsCollected) && mem.PlayerDataStringList(Offset.scenesGrubRescued).Contains("Ruins1_32"); break;
 
-                case SplitName.EnterHornet1: shouldSplit = nextScene.StartsWith("Fungus1_04") && nextScene != sceneName; break;
-                case SplitName.EnterSoulMaster: shouldSplit = nextScene.StartsWith("Ruins1_24") && nextScene != sceneName; break;
-                case SplitName.EnterHiveKnight: shouldSplit = nextScene.StartsWith("Hive_05") && nextScene != sceneName; break;
-                case SplitName.EnterHornet2: shouldSplit = nextScene.StartsWith("Deepnest_East_Hornet") && nextScene != sceneName; break;
-                case SplitName.EnterBroodingMawlek: shouldSplit = nextScene.StartsWith("Crossroads_09") && nextScene != sceneName; break;
-                case SplitName.EnterNosk: shouldSplit = nextScene.StartsWith("Deepnest_32") && nextScene != sceneName; break;
-                case SplitName.EnterTMG:
-                    shouldSplit = nextScene.StartsWith("Grimm_Main_Tent") && nextScene != sceneName
-                    && mem.PlayerData<int>(Offset.grimmChildLevel) == 2
-                    && mem.PlayerData<int>(Offset.flamesCollected) == 3; break;
-                case SplitName.EnterLoveTower: shouldSplit = nextScene.StartsWith("Ruins2_11") && nextScene != sceneName; break;
-
-                case SplitName.VengeflyKingTrans: shouldSplit = mem.PlayerData<bool>(Offset.zoteRescuedBuzzer) && nextScene != sceneName; break;
-                case SplitName.MegaMossChargerTrans: shouldSplit = mem.PlayerData<bool>(Offset.megaMossChargerDefeated) && nextScene != sceneName; break;
-                case SplitName.ElderHuTrans: shouldSplit = mem.PlayerData<bool>(Offset.killedGhostHu) && nextScene != sceneName; break;
-                case SplitName.BlackKnightTrans: shouldSplit = mem.PlayerData<bool>(Offset.killedBlackKnight) && nextScene != sceneName; break;
-                case SplitName.BrokenVesselTrans: shouldSplit = 
-                        mem.PlayerData<bool>(Offset.killedInfectedKnight) && 
-                        mem.PlayerData<int>(Offset.health) > 0 &&
-                        nextScene != sceneName; 
-                    break;
-
                 case SplitName.AbyssDoor: shouldSplit = mem.PlayerData<bool>(Offset.abyssGateOpened); break;
                 case SplitName.AbyssLighthouse: shouldSplit = mem.PlayerData<bool>(Offset.abyssLighthouse); break;
-                case SplitName.LumaflyLanternTransition: shouldSplit = mem.PlayerData<bool>(Offset.hasLantern) && !sceneName.StartsWith("Room_shop"); break;
 
                 // Spore Shroom : 17, Shape of Unn : 28, Quick Focus : 7, Baldur Shell : 5
                 case SplitName.PureSnail:

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -570,7 +570,7 @@ namespace LiveSplit.HollowKnight {
 
                 case SplitName.KingsPass: shouldSplit = currScene.StartsWith("Tutorial_01") && nextScene.StartsWith("Town"); break;
                 case SplitName.KingsPassEnterFromTown: shouldSplit = currScene.StartsWith("Town") && nextScene.StartsWith("Tutorial_01"); break;
-                case SplitName.BlueLake: shouldSplit = !currScene.StartsWith("Crossroads_50") && nextScene.StartsWith("Crossroads_50"); break;
+                case SplitName.BlueLake: shouldSplit = !currScene.StartsWith("Crossroads_50") && nextScene.StartsWith("Crossroads_50"); break; // blue lake is Crossroads_50
                 case SplitName.CatacombsEntry: shouldSplit = !currScene.StartsWith("RestingGrounds_10") && nextScene.StartsWith("RestingGrounds_10"); break;
 
                 case SplitName.EnterNKG: shouldSplit = currScene.StartsWith("Grimm_Main_Tent") && nextScene.StartsWith("Grimm_Nightmare"); break;
@@ -592,11 +592,11 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.EnterJunkPit: shouldSplit = nextScene.Equals("GG_Waterways") && nextScene != currScene; break;
                 case SplitName.EnterDeepnest:
                     shouldSplit =
-                        (nextScene.Equals("Fungus2_25") ||
-                        nextScene.Equals("Deepnest_42") ||
-                        nextScene.Equals("Abyss_03b") ||
-                        nextScene.Equals("Deepnest_01b")) &&
-                        nextScene != currScene;
+                        (nextScene.Equals("Fungus2_25")
+                        || nextScene.Equals("Deepnest_42")
+                        || nextScene.Equals("Abyss_03b")
+                        || nextScene.Equals("Deepnest_01b"))
+                        && nextScene != currScene;
                     break;
                 case SplitName.EnterBeastDen: shouldSplit = nextScene.Equals("Deepnest_Spider_Town") && nextScene != currScene; break;
                 case SplitName.EnterCrown: shouldSplit = nextScene.Equals("Mines_23") && nextScene != currScene; break;
@@ -614,21 +614,27 @@ namespace LiveSplit.HollowKnight {
                     break;
 
                 case SplitName.WaterwaysEntry:
-                    shouldSplit = (nextScene.StartsWith("Waterways_01") // Simple Key manhole entrance
-                        || nextScene.StartsWith("Waterways_07") // Right of Spike-tunnel, also where Tram entrance meets the rest
-                        ) && nextScene != currScene; break;
+                    shouldSplit =
+                        (nextScene.StartsWith("Waterways_01") // Simple Key manhole entrance
+                        || nextScene.StartsWith("Waterways_07")) // Right of Spike-tunnel, also where Tram entrance meets the rest
+                        && nextScene != currScene;
+                    break;
                 case SplitName.FogCanyonEntry:
-                    shouldSplit = (nextScene.StartsWith("Fungus3_01") // West Fog Canyon entrance from Greenpath
+                    shouldSplit =
+                        (nextScene.StartsWith("Fungus3_01") // West Fog Canyon entrance from Greenpath
                         || nextScene.StartsWith("Fungus3_02") // West Fog Canyon entrance from Queen's Station or QGA
                         || nextScene.StartsWith("Fungus3_24") // West Fog Canyon entrance from Queen's Gardens via Overgrown Mound
-                        || nextScene.StartsWith("Fungus3_26") // East Fog Canyon, where the Crossroads acid and Leg Eater acid entrances meet
-                        ) && nextScene != currScene; break;
+                        || nextScene.StartsWith("Fungus3_26")) // East Fog Canyon, where the Crossroads acid and Leg Eater acid entrances meet
+                        && nextScene != currScene;
+                    break;
                 case SplitName.FungalWastesEntry:
-                    shouldSplit = (nextScene.StartsWith("Fungus2_06") // Room outside Leg Eater
+                    shouldSplit =
+                        (nextScene.StartsWith("Fungus2_06") // Room outside Leg Eater
                         || nextScene.StartsWith("Fungus2_03") // From Queens' Station
                         || nextScene.StartsWith("Fungus2_23") // Bretta from Waterways
-                        || nextScene.StartsWith("Fungus2_20") // Spore Shroom room, from QG (this one's unlikely to come up)
-                        ) && nextScene != currScene; break;
+                        || nextScene.StartsWith("Fungus2_20")) // Spore Shroom room, from QG (this one's unlikely to come up)
+                        && nextScene != currScene;
+                    break;
 
                 case SplitName.CrystalMoundExit: shouldSplit = currScene.StartsWith("Mines_35") && nextScene != currScene; break;
                 case SplitName.CrystalPeakEntry: shouldSplit = (nextScene.StartsWith("Mines_02") || nextScene.StartsWith("Mines_10")) && nextScene != currScene; break;
@@ -638,9 +644,9 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.KingdomsEdgeEntry: shouldSplit = nextScene.StartsWith("Deepnest_East_03") && nextScene != currScene; break;
                 case SplitName.KingdomsEdgeOvercharmedEntry:
                     shouldSplit =
-                        nextScene.StartsWith("Deepnest_East_03") &&
-                        nextScene != currScene &&
-                        mem.PlayerData<bool>(Offset.overcharmed);
+                        nextScene.StartsWith("Deepnest_East_03")
+                        && nextScene != currScene
+                        && mem.PlayerData<bool>(Offset.overcharmed);
                     break;
 
                 case SplitName.GodhomeBench: shouldSplit = currScene.StartsWith("GG_Spa") && currScene != nextScene && !store.SplitThisTransition; break;
@@ -657,16 +663,31 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.TransTear: shouldSplit = mem.PlayerData<bool>(Offset.hasAcidArmour) && nextScene != currScene; break;
                 case SplitName.TransTearWithGrub:
                     shouldSplit =
-                        mem.PlayerData<bool>(Offset.hasAcidArmour) &&
-                        mem.PlayerDataStringList(Offset.scenesGrubRescued).Contains("Waterways_13") &&
+                        mem.PlayerData<bool>(Offset.hasAcidArmour)
+                        && mem.PlayerDataStringList(Offset.scenesGrubRescued).Contains("Waterways_13")
+                        && nextScene != currScene; break;
+                case SplitName.TransShadeSoul: // Should work with both normal movement and room dupes
+                    shouldSplit = mem.PlayerData<int>(Offset.fireballLevel) == 2
+                        && mem.HeroTransitionState() == HeroTransitionState.WAITING_TO_ENTER_LEVEL;
+                    break;
 
-                        nextScene != currScene; break;
-                case SplitName.TransShadeSoul: shouldSplit = mem.PlayerData<int>(Offset.fireballLevel) == 2 && nextScene != currScene; break;
-
-                case SplitName.AnyTransition: shouldSplit = shouldSplitTransition(nextScene, currScene); break;
+                case SplitName.AnyTransition:
+                    shouldSplit = nextScene != currScene && !store.SplitThisTransition
+                                    && !(string.IsNullOrEmpty(currScene) || string.IsNullOrEmpty(nextScene)
+                                        || menuingSceneNames.Contains(currScene) || menuingSceneNames.Contains(nextScene));
+                    break;
                 case SplitName.TransitionAfterSaveState:
-                    if (shouldSplitTransition(nextScene, currScene)) {
-                        shouldSplit = !(debugSaveStateSceneNames.Contains(nextScene) || debugSaveStateSceneNames.Contains(currScene));
+                    if (!(debugSaveStateSceneNames.Contains(nextScene)
+                        || debugSaveStateSceneNames.Contains(currScene))) {
+                        goto case SplitName.AnyTransition;
+                    }
+                    break;
+                case SplitName.TransitionExcludingDiscontinuities:
+                    if (!(debugSaveStateSceneNames.Contains(nextScene)
+                        || debugSaveStateSceneNames.Contains(currScene)
+                        || mem.PlayerData<int>(Offset.health) == 0
+                        || mem.EntryGateName() is "dreamGate" or "door_dreamReturn")) {
+                        goto case SplitName.AnyTransition;
                     }
                     break;
 
@@ -683,19 +704,21 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.EnterNosk: shouldSplit = nextScene.StartsWith("Deepnest_32") && nextScene != currScene; break;
                 case SplitName.EnterTMG:
                     shouldSplit = nextScene.StartsWith("Grimm_Main_Tent") && nextScene != currScene
-                    && mem.PlayerData<int>(Offset.grimmChildLevel) == 2
-                    && mem.PlayerData<int>(Offset.flamesCollected) == 3; break;
+                        && mem.PlayerData<bool>(Offset.equippedCharm_40) // Equipped Grimmchild
+                        && mem.PlayerData<int>(Offset.grimmChildLevel) == 2
+                        && mem.PlayerData<int>(Offset.flamesCollected) == 3; break;
                 case SplitName.EnterLoveTower: shouldSplit = nextScene.StartsWith("Ruins2_11") && nextScene != currScene; break;
+
+                case SplitName.EnterCityTollBenchRoom: shouldSplit = nextScene.StartsWith("Ruins1_31") && nextScene != currScene; break;
 
                 case SplitName.VengeflyKingTrans: shouldSplit = mem.PlayerData<bool>(Offset.zoteRescuedBuzzer) && nextScene != currScene; break;
                 case SplitName.MegaMossChargerTrans: shouldSplit = mem.PlayerData<bool>(Offset.megaMossChargerDefeated) && nextScene != currScene; break;
                 case SplitName.ElderHuTrans: shouldSplit = mem.PlayerData<bool>(Offset.killedGhostHu) && nextScene != currScene; break;
                 case SplitName.BlackKnightTrans: shouldSplit = mem.PlayerData<bool>(Offset.killedBlackKnight) && nextScene != currScene; break;
                 case SplitName.BrokenVesselTrans:
-                    shouldSplit =
-                        mem.PlayerData<bool>(Offset.killedInfectedKnight) &&
-                        mem.PlayerData<int>(Offset.health) > 0 &&
-                        nextScene != currScene;
+                    shouldSplit = nextScene != currScene
+                        && mem.PlayerData<bool>(Offset.killedInfectedKnight)
+                        && mem.PlayerData<int>(Offset.health) > 0;
                     break;
 
                 case SplitName.LumaflyLanternTransition: shouldSplit = mem.PlayerData<bool>(Offset.hasLantern) && !currScene.StartsWith("Room_shop"); break;

--- a/HollowKnightMemory.cs
+++ b/HollowKnightMemory.cs
@@ -13,7 +13,7 @@ namespace LiveSplit.HollowKnight {
         public bool IsHooked { get; set; }
         private DateTime lastHooked;
         private int uiManager, inputHandler, cameraCtrl, gameState, heroController, camTarget, camMode, camTMode, camDest, menuState, uiState, achievementHandler;
-        private int heroAccepting, actorState, transistionState, camTeleport, playerData, debugInfo, tilemapDirty, cState, sceneName, nextSceneName, hazardRespawning, onGround, spellquake;
+        private int heroAccepting, actorState, transistionState, camTeleport, playerData, debugInfo, tilemapDirty, cState, sceneName, nextSceneName, entryGateName, hazardRespawning, onGround, spellquake;
         //private int sceneData, awardAchievementEvent;
         private Version lastVersion;
 
@@ -35,6 +35,7 @@ namespace LiveSplit.HollowKnight {
             //sceneData = 0x34;
             sceneName = 0xc;
             nextSceneName = 0x10;
+            entryGateName = 0x14;
             uiManager = 0x84;
             inputHandler = 0x68;
             cameraCtrl = 0x74;
@@ -71,6 +72,7 @@ namespace LiveSplit.HollowKnight {
             if (MemoryReader.is64Bit) {
                 sceneName = 0x18;
                 nextSceneName = 0x20;
+                entryGateName = 0x28;
                 inputHandler = 0x40;
                 achievementHandler = 0x50;
                 cameraCtrl = 0x80;
@@ -417,6 +419,12 @@ namespace LiveSplit.HollowKnight {
             //GameManager._instance.nextSceneName
             return gameManager.Read(Program, 0x0, nextSceneName);
         }
+
+        public string EntryGateName() {
+            //GameManager._instance.entryGateName
+            return gameManager.Read(Program, 0x0, entryGateName);
+        }
+
         public bool UsesSceneTransitionRoutine() {
             /*
              * 1.3.1.5 and above swap from using LoadSceneAdditive to a SceneTransitionRoutine triggered

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -770,10 +770,10 @@ namespace LiveSplit.HollowKnight {
         TransClaw,
         [Description("Has Vengeful Spirit (Transition)"), ToolTip("Splits on transition after Vengeful Spirit acquired")]
         TransVS,
+        [Description("Has Shade Soul (Transition)"), ToolTip("Splits on transition after Shade Soul acquired (Room Dupe safe)")]
+        TransShadeSoul,
         [Description("Has Descending Dark (Transition)"), ToolTip("Splits on transition after Descending Dark acquired")]
         TransDescendingDark,
-        [Description("Has Shade Soul (Transition)"), ToolTip("Splits on transition after Shade Soul acquired")]
-        TransShadeSoul,
         [Description("Has Isma's Tear (Transition)"), ToolTip("Splits on transition after Isma's Tear acquired")]
         TransTear,
         [Description("Isma's Tear with Grub (Transition)"), ToolTip("Splits on transition after collecting Isma's Tear and saving the grub in Isma's Grove")]
@@ -808,6 +808,8 @@ namespace LiveSplit.HollowKnight {
         WaterwaysEntry,
         [Description("White Palace Entry (Transition)"), ToolTip("Splits when entering the first White Palace scene")]
         WhitePalaceEntry,
+        [Description("City Toll Bench Room (Transition)"), ToolTip("Splits when entering the city toll bench room")]
+        EnterCityTollBenchRoom,
 
         [Description("Baldur Shell (Charm)"), ToolTip("Splits when obtaining the Baldur Shell charm")]
         BaldurShell,
@@ -1658,6 +1660,8 @@ namespace LiveSplit.HollowKnight {
         AnyTransition,
         [Description("Transition excluding Save State (Transition)"), ToolTip("Splits when the knight enters a transition (excludes save states and Sly's basement)")]
         TransitionAfterSaveState,
+        [Description("Transition excluding discontinuities (Transition)"), ToolTip("Splits when the knight enters a transition (excludes discontinuities including save states, deaths, and dreamgates)")]
+        TransitionExcludingDiscontinuities,
         [Description("Manual Split (Misc)"), ToolTip("Never splits. Use this when you need to manually split while using ordered splits")]
         ManualSplit,
         [Description("Ghost Coins Incremented (Event)"), ToolTip("Splits when the ghostCoins PlayerData is updated. Unused by unmodded game, intended for use with mods.")]


### PR DESCRIPTION
Depends on #89, #90, #91, #92, #93, and #94

- Fixes EnterTMG to require Grimmchild equipped.
- Fixes TransShadeSoul to be room dupe safe.
- Adds EnterCityTollBenchRoom.
- Adds TransitionExcludingDiscontinuities.