### PR TITLE
Updated misc

### DIFF
--- a/Enums.cs
+++ b/Enums.cs
@@ -1,6 +1,7 @@
 ﻿namespace LiveSplit.HollowKnight {
     public enum Offset : int {
         health,
+        maxHealth,
         maxHealthBase,
         MPCharge,
         MPReserveMax,

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -819,6 +819,32 @@ namespace LiveSplit.HollowKnight {
 
                 #endregion Areas
 
+                #region Miscellaneous
+
+                case SplitName.ManualSplit: shouldSplit = false; break;
+
+                case SplitName.DgateKingdomsEdgeAcid:
+                    shouldSplit =
+                        mem.PlayerDataString<string>(Offset.dreamGateScene).StartsWith("Deepnest_East_04")
+                        && (mem.PlayerData<float>(Offset.dreamGateX) > 27.0f && mem.PlayerData<float>(Offset.dreamGateX) < 29f)
+                        && (mem.PlayerData<float>(Offset.dreamGateY) > 7.0f && mem.PlayerData<float>(Offset.dreamGateY) < 9f);
+                    break;
+
+                case SplitName.PureSnail: // the award for the most miscellaneous split goes to this one probably
+                    int health = mem.PlayerData<int>(Offset.health);
+                    shouldSplit = mem.Focusing() // Healing
+                        && 0 < store.HealthBeforeFocus
+                        && (store.HealthBeforeFocus < health
+                            || (health == mem.PlayerData<int>(Offset.maxHealth)
+                                && mem.PlayerData<int>(Offset.MPCharge) + 33 <= store.MPChargeBeforeFocus))
+                        && mem.PlayerData<bool>(Offset.equippedCharm_5) // Baldur Shell
+                        && mem.PlayerData<bool>(Offset.equippedCharm_7) // Quick Focus
+                        && mem.PlayerData<bool>(Offset.equippedCharm_17) // Spore Shroom
+                        && mem.PlayerData<bool>(Offset.equippedCharm_28); // Shape of Unn
+                    break;
+
+                #endregion Miscellaneous
+
                 case SplitName.Aluba: shouldSplit = mem.PlayerData<bool>(Offset.killedLazyFlyer); break;
                 case SplitName.AspidHunter: shouldSplit = mem.PlayerData<int>(Offset.killsSpitter) == 17; break;
                 case SplitName.BeastsDenTrapBench: shouldSplit = mem.PlayerData<bool>(Offset.spiderCapture); break;
@@ -1208,13 +1234,6 @@ namespace LiveSplit.HollowKnight {
 
                 case SplitName.killedSoulTwister: shouldSplit = mem.PlayerData<bool>(Offset.killedMage); break;
 
-                case SplitName.DgateKingdomsEdgeAcid:
-                    shouldSplit =
-                        mem.PlayerDataString<string>(Offset.dreamGateScene).StartsWith("Deepnest_East_04") &&
-                        (mem.PlayerData<float>(Offset.dreamGateX) > 27.0f && mem.PlayerData<float>(Offset.dreamGateX) < 29f) &&
-                        (mem.PlayerData<float>(Offset.dreamGateY) > 7.0f && mem.PlayerData<float>(Offset.dreamGateY) < 9f);
-                    break;
-
                 case SplitName.FailedChampionEssence: shouldSplit = mem.PlayerData<bool>(Offset.falseKnightOrbsCollected); break;
                 case SplitName.SoulTyrantEssence: shouldSplit = mem.PlayerData<bool>(Offset.mageLordOrbsCollected); break;
                 case SplitName.LostKinEssence: shouldSplit = mem.PlayerData<bool>(Offset.infectedKnightOrbsCollected); break;
@@ -1294,7 +1313,6 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.givenWhiteLadyFlower: shouldSplit = mem.PlayerData<bool>(Offset.givenWhiteLadyFlower); break;
                 case SplitName.givenEmilitiaFlower: shouldSplit = mem.PlayerData<bool>(Offset.givenEmilitiaFlower); break;
 
-                case SplitName.ManualSplit: shouldSplit = false; break;
                 case SplitName.OnGhostCoinsIncremented:
                     shouldSplit = store.CheckIncremented(Offset.ghostCoins);
                     break;
@@ -1375,15 +1393,6 @@ namespace LiveSplit.HollowKnight {
 
                 case SplitName.AbyssDoor: shouldSplit = mem.PlayerData<bool>(Offset.abyssGateOpened); break;
                 case SplitName.AbyssLighthouse: shouldSplit = mem.PlayerData<bool>(Offset.abyssLighthouse); break;
-
-                // Spore Shroom : 17, Shape of Unn : 28, Quick Focus : 7, Baldur Shell : 5
-                case SplitName.PureSnail:
-                    shouldSplit = store.CheckIncreasedBy(Offset.health, 1) &&
-                        mem.PlayerData<bool>(Offset.equippedCharm_5) &&
-                        mem.PlayerData<bool>(Offset.equippedCharm_7) &&
-                        mem.PlayerData<bool>(Offset.equippedCharm_17) &&
-                        mem.PlayerData<bool>(Offset.equippedCharm_28);
-                    break;
 
 
                 #region Trial of the Warrior

--- a/HollowKnightMemory.cs
+++ b/HollowKnightMemory.cs
@@ -13,7 +13,7 @@ namespace LiveSplit.HollowKnight {
         public bool IsHooked { get; set; }
         private DateTime lastHooked;
         private int uiManager, inputHandler, cameraCtrl, gameState, heroController, camTarget, camMode, camTMode, camDest, menuState, uiState, achievementHandler;
-        private int heroAccepting, actorState, transistionState, camTeleport, playerData, debugInfo, tilemapDirty, cState, sceneName, nextSceneName, entryGateName, hazardRespawning, onGround, spellquake;
+        private int heroAccepting, actorState, transistionState, camTeleport, playerData, debugInfo, tilemapDirty, cState, sceneName, nextSceneName, entryGateName, hazardRespawning, onGround, spellquake, focusing;
         //private int sceneData, awardAchievementEvent;
         private Version lastVersion;
 
@@ -63,6 +63,7 @@ namespace LiveSplit.HollowKnight {
             hazardRespawning = 0x26;
             onGround = 0x9;
             spellquake = 0x37;
+            focusing = 0x39;
 
             int versionString = 0x1c;
             string version;
@@ -105,6 +106,7 @@ namespace LiveSplit.HollowKnight {
                 hazardRespawning = 0x2e;
                 onGround = 0x11;
                 spellquake = 0x3f;
+                focusing = 0x41;
 
                 versionString = 0x38;
 
@@ -449,6 +451,10 @@ namespace LiveSplit.HollowKnight {
         public bool Spellquake() {
             //GameManager._instance.hero_ctrl.cState.spellquake
             return gameManager.Read<bool>(Program, 0x0, heroController, cState, spellquake);
+        }
+        public bool Focusing() {
+            //GameManager._instance.hero_ctrl.cState.focusing
+            return gameManager.Read<bool>(Program, 0x0, heroController, cState, focusing);
         }
         public string AchievementKey() {
             IntPtr basePointer = gameManager.Read<IntPtr>(Program, 0x0, achievementHandler);

--- a/HollowKnightStoredData.cs
+++ b/HollowKnightStoredData.cs
@@ -23,6 +23,8 @@ namespace LiveSplit.HollowKnight
         private ConcurrentDictionary<Offset, Tracked<bool>> pdBools = new ConcurrentDictionary<Offset, Tracked<bool>>();
         public bool TraitorLordDeadOnEntry { get; private set; } = false;
         public bool DungDefenderAwakeConvoOnEntry { get; private set; } = false;
+        public int HealthBeforeFocus { get; private set; } = 0;
+        public int MPChargeBeforeFocus { get; private set; } = 0;
         /// <summary>
         /// Returns true if the knight is currently in a transition and has already split there
         /// </summary>
@@ -68,6 +70,8 @@ namespace LiveSplit.HollowKnight
             pdBools.Clear();
             TraitorLordDeadOnEntry = false;
             DungDefenderAwakeConvoOnEntry = false;
+            HealthBeforeFocus = 0;
+            MPChargeBeforeFocus = 0;
             SplitThisTransition = false;
             GladeEssence = 0;
             ResetKills();
@@ -201,6 +205,10 @@ namespace LiveSplit.HollowKnight
         public void Update() {
             if (mem.SceneName() == "RestingGrounds_08" && CheckIncremented(Offset.dreamOrbs)) {
                 GladeEssence++;
+            }
+            if (!mem.Focusing()) {
+                HealthBeforeFocus = mem.PlayerData<int>(Offset.health);
+                MPChargeBeforeFocus = mem.PlayerData<int>(Offset.MPCharge);
             }
             foreach (Offset offset in pdInts.Keys) {
                 pdInts[offset].Update(mem.PlayerData<int>(offset));


### PR DESCRIPTION
Fixes Pure Snail to allow completing a focus at full health

Depends on #89, #90, #91, #92, #93, #94, #95, #96, #97, and #98

Pure Snail splits when focusing with Spore Shroom, Quick Focus, Baldur Shell, and Shape of Unn equipped.

Testing:
 - [x] Split when focusing to heal and gain health
 - [x] Split when focusing while already at full health
 - [x] Don't split when gaining health by benching
 - [x] Don't split when the focus is interrupted before complete

Slight problems discovered in testing:
 - Currently it splits when focusing and gaining health in a hotspring, but it may split when the hotspring grants health, before the focus is complete.
 - Also, currently it does not split when focusing while already at full health in a hotspring, since the hotspring replenishes soul fast enough that the code can't tell when a focus has completed.