### PR TITLE
WaterwaysEntry: include Spike-tunnel left

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -618,6 +618,7 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.WaterwaysEntry:
                     shouldSplit =
                         (nextScene.StartsWith("Waterways_01") // Simple Key manhole entrance
+                        || nextScene.StartsWith("Waterways_06") // Left of Spike-tunnel
                         || nextScene.StartsWith("Waterways_07")) // Right of Spike-tunnel, also where Tram entrance meets the rest
                         && nextScene != currScene;
                     break;

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -812,7 +812,7 @@ namespace LiveSplit.HollowKnight {
         EnterSanctumWithShadeSoul,
         [Description("Tower of Love (Transition)"), ToolTip("Splits when entering the Tower of Love")]
         EnterLoveTower,
-        [Description("Waterways (Transition)"), ToolTip("Splits on transition to Waterways\n(Simple Key manhole or right of Spike-tunnel)")]
+        [Description("Waterways (Transition)"), ToolTip("Splits on transition to Waterways\n(Simple Key manhole or Spike-tunnel)")]
         WaterwaysEntry,
         [Description("White Palace Entry (Transition)"), ToolTip("Splits when entering the first White Palace scene")]
         WhitePalaceEntry,


### PR DESCRIPTION
Currently the Enter Waterways autosplit recognizes Spike-tunnel going right, but not going left... this PR makes it recognize both left and right. This would be used for the Duelist / Bosses Only No Kill meme category to go towards Dung Defender.

I have a branch with the dll built for local testing here:
https://github.com/AlexKnauth/LiveSplit.HollowKnight/tree/waterways-spike-tunnel-dll

Testing:
- [x] Splits when entering Waterways via Spike-tunnel going left