### PR TITLE
StartNewGame: check opening scenes

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -303,7 +303,8 @@ namespace LiveSplit.HollowKnight {
 
                 case SplitName.StartNewGame:
                     shouldSplit =
-                        (nextScene.Equals("Tutorial_01", StringComparison.OrdinalIgnoreCase)
+                        (currScene is "Intro_Cutscene" or "Opening_Sequence"
+                        && nextScene.Equals("Tutorial_01", StringComparison.OrdinalIgnoreCase)
                         && mem.GameState() == GameState.ENTERING_LEVEL)
                         || nextScene is "GG_Entrance_Cutscene";
                     break;


### PR DESCRIPTION
> I've tried timing things while near kp, it's super annoying

This PR changes `StartNewGame` to only start when actually starting a new game. Anyone wanting to run "New Game Plus" categories should avoid `StartNewGame` and just leave NO start-triggering autosplit for default/legacy behavior.

This PR does *not* change the default behavior when start-triggering autosplit is off.

Testing https://github.com/AlexKnauth/LiveSplit.HollowKnight/tree/StartNewGame-dll:
- [ ] Splits on starting a new game
- [ ] Does not split on just "being" in KP when you reset
- [ ] Does not split on entering KP from Dirtmouth
- [ ] Does not split on entering KP from Cliffs
- [ ] Timing spread matches default/legacy timings: need less than 0.07 seconds of spread
- [ ] Timing average matches default/legacy timings: need less than 0.03 seconds of delta