### PR TITLE
Add Stagnest Buy split

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -798,6 +798,7 @@ namespace LiveSplit.HollowKnight {
                     shouldSplit = nextScene.Equals("Cliffs_03", StringComparison.OrdinalIgnoreCase)
                         && mem.PlayerData<bool>(Offset.travelling)
                         && mem.PlayerData<bool>(Offset.openedStagNest); break;
+                case SplitName.StagnestStationBuy: shouldSplit = mem.PlayerData<bool>(Offset.openedStagNest); break;
                 case SplitName.StoreroomsStation: shouldSplit = mem.PlayerData<bool>(Offset.openedRuins1); break;
 
                 #endregion Stags

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -668,7 +668,7 @@ namespace LiveSplit.HollowKnight {
         RestingGroundsStation,
         [Description("Distant Village (Stag Station)"), ToolTip("Splits when obtaining Distant Village Stag Station")]
         DeepnestStation,
-        [Description("Hidden Station (Stag Station)"), ToolTip("Splits when obtaining to Hidden Station Stag Station")]
+        [Description("Hidden Station (Stag Station)"), ToolTip("Splits when obtaining Hidden Station Stag Station")]
         HiddenStationStation,
         [Description("Stagnest (Stag Station)"), ToolTip("Splits when traveling to Stagnest (Requires Ordered Splits)")]
         StagnestStation,

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -672,7 +672,7 @@ namespace LiveSplit.HollowKnight {
         HiddenStationStation,
         [Description("Stagnest (Stag Station)"), ToolTip("Splits when traveling to Stagnest (Requires Ordered Splits)")]
         StagnestStation,
-        [Description("Stagnest Buy (Stag Station)"), ToolTip("Splits when obtaining Stagnest Station")]
+        [Description("Stagnest Buy (Stag Station)"), ToolTip("Splits when obtaining Stagnest Station (Not for All Stag Stations)")]
         StagnestStationBuy,
 
         [Description("Mr. Mushroom 1 (Spot)"), ToolTip("Splits when talking to Mister Mushroom in Fungal Wastes")]

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -672,6 +672,8 @@ namespace LiveSplit.HollowKnight {
         HiddenStationStation,
         [Description("Stagnest (Stag Station)"), ToolTip("Splits when traveling to Stagnest (Requires Ordered Splits)")]
         StagnestStation,
+        [Description("Stagnest Buy (Stag Station)"), ToolTip("Splits when obtaining Stagnest Station")]
+        StagnestStationBuy,
 
         [Description("Mr. Mushroom 1 (Spot)"), ToolTip("Splits when talking to Mister Mushroom in Fungal Wastes")]
         MrMushroom1,


### PR DESCRIPTION
Adds a split that is supposed to be used for buying Stagnest Station, but also splits when obtaining Stagnest Station in general. 

Also fixed the tooltip for Hidden Station Stag.