### PR TITLE
Updated Menu splits from Mayo

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -217,20 +217,7 @@ namespace LiveSplit.HollowKnight {
             foreach (SplitName Split in settings.Splits) {
                 if (splitsDone.Contains(Split)) {
                     continue;
-                } else if (Split.ToString().StartsWith("Menu")) {
-                    if (!menuSplitHelper)
-                        menuSplitHelper = Split == SplitName.Menu ||
-                            CheckSplit(Split, nextScene, sceneName) == SplitterAction.Split && !((gameState == GameState.INACTIVE && uIState == UIState.INACTIVE) || (gameState == GameState.MAIN_MENU));
-                    if (menuSplitHelper) {
-                        if (CheckSplit(SplitName.Menu, nextScene, sceneName) == SplitterAction.Split) {
-                            splitsDone.Add(Split);
-                            lastSplitDone = Split;
-                            menuSplitHelper = false;
-                            if (hasLog || !Console.IsOutputRedirected) WriteLogWithTime("Split: " + Split);
-                            return SplitterAction.Split;
-                        }
-                    }
-                } else if (!((gameState == GameState.INACTIVE && uIState == UIState.INACTIVE) || (gameState == GameState.MAIN_MENU))) {
+                } else if (Split.ToString().StartsWith("Menu") || !((gameState == GameState.INACTIVE && uIState == UIState.INACTIVE) || (gameState == GameState.MAIN_MENU))) {
                     if (CheckSplit(Split, nextScene, sceneName) == SplitterAction.Split) {
                         splitsDone.Add(Split);
                         lastSplitDone = Split;
@@ -246,30 +233,16 @@ namespace LiveSplit.HollowKnight {
         private SplitterAction OrderedSplits(GameState gameState, UIState uIState, string nextScene, string sceneName) {
             SplitName Split = settings.Splits[currentSplit];
 
-            if (Split.ToString().StartsWith("Menu")) {
-                if (!menuSplitHelper) menuSplitHelper = Split == SplitName.Menu || CheckSplit(Split, nextScene, sceneName) != SplitterAction.Pass;
-                if (menuSplitHelper) {
-                    if (CheckSplit(SplitName.Menu, nextScene, sceneName) == SplitterAction.Split) {
-                        menuSplitHelper = false;
-                        if (hasLog || !Console.IsOutputRedirected) WriteLogWithTime("Split: " + Split);
-                        return SplitterAction.Split;
-                    } else if (CheckSplit(SplitName.Menu, nextScene, sceneName) == SplitterAction.Skip) {
-                        menuSplitHelper = false;
-                        if (hasLog || !Console.IsOutputRedirected) WriteLogWithTime("Skip: " + Split);
-                        return SplitterAction.Skip;
-                    }
-                }
-            } else {
-                if (CheckSplit(Split, nextScene, sceneName) == SplitterAction.Split
-                        && !((gameState == GameState.INACTIVE && uIState == UIState.INACTIVE) || (gameState == GameState.MAIN_MENU))) {
+            if (Split.ToString().StartsWith("Menu") || !((gameState == GameState.INACTIVE && uIState == UIState.INACTIVE) || (gameState == GameState.MAIN_MENU))) {
+                SplitterAction action = CheckSplit(Split, nextScene, sceneName);
+
+                if (action == SplitterAction.Split) {
                     if (hasLog || !Console.IsOutputRedirected) WriteLogWithTime("Split: " + Split);
                     return SplitterAction.Split;
-                } else if (CheckSplit(Split, nextScene, sceneName) == SplitterAction.Skip
-                        && !((gameState == GameState.INACTIVE && uIState == UIState.INACTIVE) || (gameState == GameState.MAIN_MENU))) {
+                } else if (action == SplitterAction.Skip) {
                     if (hasLog || !Console.IsOutputRedirected) WriteLogWithTime("Skip: " + Split);
                     return SplitterAction.Skip;
-                } else if (CheckSplit(Split, nextScene, sceneName) == SplitterAction.Reset
-                        && !((gameState == GameState.INACTIVE && uIState == UIState.INACTIVE) || (gameState == GameState.MAIN_MENU))) {
+                } else if (action == SplitterAction.Reset) {
                     if (hasLog || !Console.IsOutputRedirected) WriteLogWithTime("Reset: " + Split);
                     return SplitterAction.Reset;
                 }
@@ -277,6 +250,12 @@ namespace LiveSplit.HollowKnight {
             return SplitterAction.Pass;
         }
 
+        private bool MenuSplitHelper(bool pre) {
+            if (mem.GameState() is GameState.PLAYING or GameState.CUTSCENE) {
+                menuSplitHelper = pre;
+            }
+            return menuSplitHelper;
+        }
 
         private SplitterAction CheckSplit(SplitName split, string nextScene, string currScene) {
             bool shouldSplit = false;
@@ -1321,16 +1300,31 @@ namespace LiveSplit.HollowKnight {
 
                 #region Main Menu
 
-                case SplitName.Menu: shouldSplit = currScene == "Menu_Title"; break;
-                case SplitName.MenuClaw: shouldSplit = mem.PlayerData<bool>(Offset.hasWallJump); break;
-                case SplitName.MenuGorgeousHusk: shouldSplit = mem.PlayerData<bool>(Offset.killedGorgeousHusk); break;
-                case SplitName.MenuIsmasTear: shouldSplit = mem.PlayerData<bool>(Offset.hasAcidArmour); break;
-                case SplitName.MenuShadeSoul: shouldSplit = mem.PlayerData<int>(Offset.fireballLevel) == 2; break;
+                // this case is used for all main menu splits, be careful if you modify it
+                case SplitName.Menu:
+                    shouldSplit = currScene == "Menu_Title";
+                    break;
+
+                // menuSplitHelper is set to true in case SplitName.Menu, and is only set back to false once it splits
+                // playerdata doesn't exist when you quit out or something so it can't check any additional conditions
+                // menuSplitHelper basically just remembers that you've met the conditions and lets you pass on to the
+                // SplitName.Menu case.
+
+                case SplitName.MenuCloak: if (MenuSplitHelper(mem.PlayerData<bool>(Offset.hasDash))) { goto case SplitName.Menu; } break;
+                case SplitName.MenuClaw: if (MenuSplitHelper(mem.PlayerData<bool>(Offset.hasWallJump))) { goto case SplitName.Menu; } break;
+                case SplitName.MenuDashmaster: if (MenuSplitHelper(mem.PlayerData<bool>(Offset.gotCharm_31))) { goto case SplitName.Menu; } break;
+                case SplitName.MenuGorgeousHusk: if (MenuSplitHelper(mem.PlayerData<bool>(Offset.killedGorgeousHusk))) { goto case SplitName.Menu; } break;
+                case SplitName.MenuDreamNail: if (MenuSplitHelper(mem.PlayerData<bool>(Offset.hasDreamNail))) { goto case SplitName.Menu; } break;
+                case SplitName.MenuDreamGate: if (MenuSplitHelper(mem.PlayerData<bool>(Offset.hasDreamGate))) { goto case SplitName.Menu; } break;
+                case SplitName.MenuDreamer3: if (MenuSplitHelper(mem.PlayerData<int>(Offset.guardiansDefeated) == 3)) { goto case SplitName.Menu; } break;
+                case SplitName.MenuVoidHeart: if (MenuSplitHelper(mem.PlayerData<bool>(Offset.gotShadeCharm))) { goto case SplitName.Menu; } break;
+                case SplitName.MenuIsmasTear: if (MenuSplitHelper(mem.PlayerData<bool>(Offset.hasAcidArmour))) { goto case SplitName.Menu; }; break;
+                case SplitName.MenuShadeSoul: if (MenuSplitHelper(mem.PlayerData<int>(Offset.fireballLevel) == 2)) { goto case SplitName.Menu; }; break;
 
                 // Main Menu Dreamers for quitouts
-                case SplitName.MenuLurien: shouldSplit = mem.PlayerData<bool>(Offset.lurienDefeated); break;
-                case SplitName.MenuMonomon: shouldSplit = mem.PlayerData<bool>(Offset.monomonDefeated); break;
-                case SplitName.MenuHegemol: shouldSplit = mem.PlayerData<bool>(Offset.hegemolDefeated); break;
+                case SplitName.MenuLurien: if (MenuSplitHelper(mem.PlayerData<bool>(Offset.lurienDefeated))) { goto case SplitName.Menu; } break;
+                case SplitName.MenuMonomon: if (MenuSplitHelper(mem.PlayerData<bool>(Offset.monomonDefeated))) { goto case SplitName.Menu; } break;
+                case SplitName.MenuHegemol: if (MenuSplitHelper(mem.PlayerData<bool>(Offset.hegemolDefeated))) { goto case SplitName.Menu; } break;
 
                 #endregion Main Menu
 

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -2208,6 +2208,7 @@ namespace LiveSplit.HollowKnight {
             currentSplit--;
             //if (!settings.Ordered) splitsDone.Remove(lastSplitDone); Reminder of THIS BREAKS THINGS
             state = 0;
+            menuSplitHelper = false;
         }
         public void OnSkipSplit(object sender, EventArgs e) {
             currentSplit++;

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -1457,12 +1457,24 @@ namespace LiveSplit.HollowKnight {
         Menu,
         [Description("Main Menu w/ Claw (Menu)"), ToolTip("Splits on transition to the main menu after Mantis Claw acquired")]
         MenuClaw,
+        [Description("Main Menu w/ Mothwing Cloak (Menu)"), ToolTip("Splits on transition to the main menu after Mothwing Cloak acquired")]
+        MenuCloak,
+        [Description("Main Menu w/ Dashmaster (Menu)"), ToolTip("Splits on transition to the main menu after Dashmaster acquired")]
+        MenuDashmaster,
+        [Description("Main Menu w/ Dream Nail (Menu)"), ToolTip("Splits on transition to the main menu after Dream Nail acquired")]
+        MenuDreamNail,
+        [Description("Main Menu w/ Dream Gate (Menu)"), ToolTip("Splits on transition to the main menu after Dream Gate acquired")]
+        MenuDreamGate,
+        [Description("Main Menu w/ 3 Dreamers (Menu)"), ToolTip("Splits on transition to the main menu after 3 Dreamers acquired")]
+        MenuDreamer3,
         [Description("Main Menu w/ Ghusk (Menu)"), ToolTip("Splits on transition to the main menu after Gorgeous Husk defeated")]
         MenuGorgeousHusk,
         [Description("Main Menu w/ Isma's Tear (Menu)"), ToolTip("Splits on transition to the main menu after Isma's Tear acquired")]
         MenuIsmasTear,
         [Description("Main Menu w/ Shade Soul (Menu)"), ToolTip("Splits on transition to the main menu after Shade Soul acquired")]
         MenuShadeSoul,
+        [Description("Main Menu w/ Void Heart (Menu)"), ToolTip("Splits on transition to the main menu after Void Heart acquired")]
+        MenuVoidHeart,
 
         [Description("Main Menu w/ Herrah (Menu)"), ToolTip("For Dreamer Quit-outs on older patches. Splits on transition to the main menu after Herrah is registered as defeated")]
         MenuHegemol,
@@ -1470,7 +1482,7 @@ namespace LiveSplit.HollowKnight {
         MenuLurien,
         [Description("Main Menu w/ Monomon (Menu)"), ToolTip("For Dreamer Quit-outs on older patches. Splits on transition to the main menu after Monomon is registered as defeated")]
         MenuMonomon,
-        
+
         [Description("Cornifer at Home (Transition)"), ToolTip("Splits when entering Iselda's hut while Cornifer is sleeping")]
         CorniferAtHome,
         [Description("All Seals (Item)"), ToolTip("Splits when 17 Hallownest Seals have been collected")]


### PR DESCRIPTION
- Added Menu splits for Mothwing Cloak, Dashmaster, Dream Nail, Dream Gate, Void Heart and 3 Dreamers (Mayo)
- Fixed Main Menu splits to be more reliable (Mayo, AlexKnauth)

I have a branch with the dll built here for testing: https://github.com/AlexKnauth/LiveSplit.HollowKnight/tree/mayo-menu-dll

Testing:
- [x] Menu splits don't split on menu after condition was true but becomes false
  - [x] `MenuCloak`: Debug dash on, dash off, quit-out (should not split)
  - [x] `MenuClaw`: Dash->Claw IL, get claw, reset, load savestate, get dash (should start), quit-out (should not end)
- [x] "Menu w/ X" splits don't split on the main menu multiple times per menu
  - [x] `MenuCloak`, `MenuClaw`
  - [x] `MenuCloak`, `MenuCloak`
- [x] "Menu w/ X" splits work properly with the various early-controls, dreamer quit-outs, etc.
  - [x] `MenuDashmaster`: waah! early-control
  - [x] `MenuClaw`: mantis youth early-control (1221)
    - Including with `MantisClaw`, `MenuClaw` in sequence
  - [x] `MenuShadeSoul`: folly early-control (1221: note, probably stupid because lever skip exists, and also text storage exists)
  - [x] `MenuIsmasTear`: hwurmp early-control
  - [x] `MenuHegemol`: dreamer quit-out (1221)
- [x] "Menu w/ X" splits don't split if you start the timer on the menu
  - [x] `MenuCloak`: Debug dash on, quit-out (should start), reset (should not start), load in (should not start)
- [x] Skipping splits doesn't break it
  - [x] `MenuCloak`, `MenuClaw`: get dash, pause, manually skip split, quit-out (should not split `MenuClaw`), get claw, quit-out (should split)
  - [x] `MenuCloak`, `MantisClaw`: get dash, pause, manually skip split, quit-out (should not split), get claw (should split)
- [x] Undoing splits doesn't break it
  - [x] `MenuClaw`, `MenuCloak`, `MantisClaw`: manually split `MenuClaw`, get dash, pause, manually undo `MenuClaw`, quit-out (should not split `MenuClaw`)
    - I don't expect it to split `MenuCloak` in this situation
    - If I manually skip `MenuClaw` after I'm already on the main menu, does it split `MenuCloak` on loading back into the file from the menu? (Answer: No, though it does split on the next quit-out to main menu.)
    - I expect `MantisClaw` to split properly when getting Claw after this, of course.