### PR TITLE
Add BasinSpikePitExit transition split

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -631,6 +631,7 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.CrystalPeakEntry: shouldSplit = (nextScene.StartsWith("Mines_02") || nextScene.StartsWith("Mines_10")) && nextScene != currScene; break;
                 case SplitName.QueensGardensEntry: shouldSplit = (nextScene.StartsWith("Fungus3_34") || nextScene.StartsWith("Deepnest_43")) && nextScene != currScene; break;
                 case SplitName.BasinEntry: shouldSplit = nextScene.StartsWith("Abyss_04") && nextScene != currScene; break;
+                case SplitName.BasinSpikePitExit: shouldSplit = currScene.StartsWith("Abyss_18") && nextScene.StartsWith("Abyss_19"); break;
                 case SplitName.HiveEntry: shouldSplit = nextScene.StartsWith("Hive_01") && nextScene != currScene; break;
                 case SplitName.KingdomsEdgeEntry: shouldSplit = nextScene.StartsWith("Deepnest_East_03") && nextScene != currScene; break;
                 case SplitName.KingdomsEdgeOvercharmedEntry:

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -730,6 +730,8 @@ namespace LiveSplit.HollowKnight {
         AncestralMound,
         [Description("Ancient Basin (Transition)"), ToolTip("Splits on transition to Ancient Basin")]
         BasinEntry,
+        [Description("Basin Spike Pit Exit (Transition)"), ToolTip("Splits on transition after crossing the Spike Pit from Basin Toll Bench towards Broken Vessel")]
+        BasinSpikePitExit,
         [Description("Beast Den (Transition)"), ToolTip("Splits on transition into Beast Den")]
         EnterBeastDen,
         [Description("Blue Lake (Transition)"), ToolTip("Splits on transition to Blue Lake from either side")]


### PR DESCRIPTION
Splits on transition after crossing the Spike Pit from Basin Toll Bench towards Broken Vessel.

Resolves #131 

Testing:
- [x] Does not split when exiting from the Basin Toll Bench to the right
- [x] Splits when exiting from the Spike Pit to the left
- [x] Does not split when entering Broken Vessel from the bottom
