### PR TITLE
Add LemmShopExit transition split

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -572,6 +572,7 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.EnterCrown: shouldSplit = nextScene.Equals("Mines_23") && nextScene != currScene; break;
                 case SplitName.EnterDirtmouth: shouldSplit = nextScene.Equals("Town") && nextScene != currScene; break;
                 case SplitName.EnterRafters: shouldSplit = nextScene.Equals("Ruins1_03") && nextScene != currScene; break;
+                case SplitName.LemmShopExit: shouldSplit = mem.PlayerData<bool>(Offset.metRelicDealerShop) && currScene.StartsWith("Ruins1_05b") && nextScene != currScene; break;
                 case SplitName.SalubraExit: shouldSplit = currScene.Equals("Room_Charm_Shop") && nextScene != currScene; break;
                 // since Ruins1_18 has both bench and bridge, don't include Ruins1_18 bridge to Ruins2_03b
                 case SplitName.SpireBenchExit: shouldSplit = currScene.StartsWith("Ruins1_18") && nextScene.StartsWith("Ruins2_01"); break;

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -776,6 +776,8 @@ namespace LiveSplit.HollowKnight {
         EnterCrown,
         [Description("Rafters (Transition)"), ToolTip("Splits on any transition into the City Rafters room")]
         EnterRafters,
+        [Description("Lemm Shop Exit (Transition)"), ToolTip("Splits on transition after talking to Lemm in the shop")]
+        LemmShopExit,
         [Description("Salubra Exit (Transition)"), ToolTip("Splits on the transition out of Salubra's Hut")]
         SalubraExit,
         [Description("Spire Bench Exit (Transition)"), ToolTip("Splits on the transition out of the bench room in Watcher's Spire")]


### PR DESCRIPTION
Splits on transition after talking to Lemm in the shop.

Resolves #120 

Testing:
- [x] 1578
  - [x] Does not split when just passing through underneath Lemm on rafters route
  - [x] Does not split when just passing through from the top towards the Fountain on pre-rafters route
  - [x] Splits after selling to Lemm and exiting towards the Fountain
- [x] 1221
  - [x] Does not split when just passing through underneath Lemm on rafters route
  - [x] Does not split when just passing through from the top towards the Fountain on pre-rafters route
  - [x] Splits after selling to Lemm and exiting towards the Fountain
- [x] 1028
  - [x] Does not split when just passing through underneath Lemm on rafters route
  - [x] Does not split when just passing through from the top towards the Fountain on pre-rafters route
  - [x] Splits after selling to Lemm and exiting towards the Fountain
