### PR TITLE
Add EnterCrossroads transition split

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -543,6 +543,7 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.CatacombsEntry: shouldSplit = !currScene.StartsWith("RestingGrounds_10") && nextScene.StartsWith("RestingGrounds_10"); break;
 
                 case SplitName.EnterNKG: shouldSplit = currScene.StartsWith("Grimm_Main_Tent") && nextScene.StartsWith("Grimm_Nightmare"); break;
+                case SplitName.EnterCrossroads: shouldSplit = nextScene.StartsWith("Crossroads_01") && nextScene != currScene; break;
                 case SplitName.EnterGreenpath: shouldSplit = !currScene.StartsWith("Fungus1_01") && nextScene.StartsWith("Fungus1_01"); break;
                 case SplitName.EnterGreenpathWithOvercharm:
                     shouldSplit = !currScene.StartsWith("Fungus1_01")

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -750,6 +750,8 @@ namespace LiveSplit.HollowKnight {
         CrystalPeakEntry,
         [Description("Crystal Mound Exit (Transition)"), ToolTip("Splits on transition from Crystal Mound")]
         CrystalMoundExit,
+        [Description("Crossroads (Transition)"), ToolTip("Splits on transition through the Well from Dirtmouth to Crossroads")]
+        EnterCrossroads,
         [Description("Deepnest (Transition)"), ToolTip("Splits on transition into Deepnest")]
         EnterDeepnest,
         [Description("Dirtmouth (Transition)"), ToolTip("Splits on any transition into Dirtmouth Town")]


### PR DESCRIPTION
Splits on transition through the Well from Dirtmouth to Crossroads.

Resolves #135 

Testing:
- [x] Splits on transition through the Well from Dirtmouth to Crossroads