### PR TITLE
Add EnterQueensGardensOrDeepnest transition split

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -570,7 +570,7 @@ namespace LiveSplit.HollowKnight {
                     shouldSplit =
                         (nextScene.Equals("Fungus2_25") // From Mantis Lords or Fungal Core
                         || nextScene.Equals("Deepnest_42") // From Queen's Gardens
-                        || nextScene.Equals("Abyss_03b") // From Tram
+                        || nextScene.Equals("Abyss_03_b") // From Tram
                         || nextScene.Equals("Deepnest_01b")) // From Fungal near Spore Shroom
                         && nextScene != currScene;
                     break;
@@ -620,7 +620,7 @@ namespace LiveSplit.HollowKnight {
                     shouldSplit =
                         (nextScene.StartsWith("Fungus3_34") // Queen's Gardens entrance from QGA or Overgrown Mound
                         || nextScene.Equals("Fungus2_25") // Deepnest entrance from Mantis Lords or Fungal Core
-                        || nextScene.Equals("Abyss_03b") // Deepnest entrance from Tram
+                        || nextScene.Equals("Abyss_03_b") // Deepnest entrance from Tram
                         || nextScene.Equals("Deepnest_01b")) // Deepnest entrance from Fungal near Spore Shroom
                         && nextScene != currScene;
                     break;

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -568,10 +568,10 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.EnterJunkPit: shouldSplit = nextScene.Equals("GG_Waterways") && nextScene != currScene; break;
                 case SplitName.EnterDeepnest:
                     shouldSplit =
-                        (nextScene.Equals("Fungus2_25")
-                        || nextScene.Equals("Deepnest_42")
-                        || nextScene.Equals("Abyss_03b")
-                        || nextScene.Equals("Deepnest_01b"))
+                        (nextScene.Equals("Fungus2_25") // From Mantis Lords or Fungal Core
+                        || nextScene.Equals("Deepnest_42") // From Queen's Gardens
+                        || nextScene.Equals("Abyss_03b") // From Tram
+                        || nextScene.Equals("Deepnest_01b")) // From Fungal near Spore Shroom
                         && nextScene != currScene;
                     break;
                 case SplitName.EnterBeastDen: shouldSplit = nextScene.Equals("Deepnest_Spider_Town") && nextScene != currScene; break;
@@ -616,6 +616,14 @@ namespace LiveSplit.HollowKnight {
 
                 case SplitName.CrystalMoundExit: shouldSplit = currScene.StartsWith("Mines_35") && nextScene != currScene; break;
                 case SplitName.CrystalPeakEntry: shouldSplit = (nextScene.StartsWith("Mines_02") || nextScene.StartsWith("Mines_10")) && nextScene != currScene; break;
+                case SplitName.EnterQueensGardensOrDeepnest:
+                    shouldSplit =
+                        (nextScene.StartsWith("Fungus3_34") // Queen's Gardens entrance from QGA or Overgrown Mound
+                        || nextScene.Equals("Fungus2_25") // Deepnest entrance from Mantis Lords or Fungal Core
+                        || nextScene.Equals("Abyss_03b") // Deepnest entrance from Tram
+                        || nextScene.Equals("Deepnest_01b")) // Deepnest entrance from Fungal near Spore Shroom
+                        && nextScene != currScene;
+                    break;
                 case SplitName.QueensGardensEntry: shouldSplit = (nextScene.StartsWith("Fungus3_34") || nextScene.StartsWith("Deepnest_43")) && nextScene != currScene; break;
                 case SplitName.BasinEntry: shouldSplit = nextScene.StartsWith("Abyss_04") && nextScene != currScene; break;
                 case SplitName.BasinSpikePitExit: shouldSplit = currScene.StartsWith("Abyss_18") && nextScene.StartsWith("Abyss_19"); break;

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -811,6 +811,8 @@ namespace LiveSplit.HollowKnight {
         KingdomsEdgeOvercharmedEntry,
         [Description("NKG Dream (Transition)"), ToolTip("Splits on transition into Nightmare King Grimm dream")]
         EnterNKG,
+        [Description("Queen's Gardens or Deepnest (Transition)"), ToolTip("Splits on transition into either Queen's Gardens or Deepnest")]
+        EnterQueensGardensOrDeepnest,
         [Description("Queen's Garden Entry (Transition)"), ToolTip("Splits on transition to QG scene following QGA or above Deepnest")]
         QueensGardensEntry,
         [Description("Queen's Garden - Frogs (Transition)"), ToolTip("Splits on transition to QG frogs scene")]

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -813,11 +813,11 @@ namespace LiveSplit.HollowKnight {
         EnterNKG,
         [Description("Queen's Gardens or Deepnest (Transition)"), ToolTip("Splits on transition into either Queen's Gardens or Deepnest")]
         EnterQueensGardensOrDeepnest,
-        [Description("Queen's Garden Entry (Transition)"), ToolTip("Splits on transition to QG scene following QGA or above Deepnest")]
+        [Description("Queen's Gardens Entry (Transition)"), ToolTip("Splits on transition to QG scene following QGA or above Deepnest")]
         QueensGardensEntry,
-        [Description("Queen's Garden - Frogs (Transition)"), ToolTip("Splits on transition to QG frogs scene")]
+        [Description("Queen's Gardens - Frogs (Transition)"), ToolTip("Splits on transition to QG frogs scene")]
         QueensGardensFrogsTrans,
-        [Description("Queen's Garden - Post-Upper Arena (Transition)"), ToolTip("Splits on transition to room after upper arena in QG")]
+        [Description("Queen's Gardens - Post-Upper Arena (Transition)"), ToolTip("Splits on transition to room after upper arena in QG")]
         QueensGardensPostArenaTransition,
         [Description("Soul Sanctum (Transition)"), ToolTip("Splits when entering Soul Sanctum")]
         EnterSanctum,
@@ -1369,7 +1369,7 @@ namespace LiveSplit.HollowKnight {
         BenchCG1,
         [Description("Grey Mourner (Bench)"), ToolTip("Splits when sitting on the bench by the Grey Mourner")]
         BenchFlowerQuest,
-        [Description("Queen's Garden Cornifer (Bench)"), ToolTip("Splits when sitting on the bench by Cornifer in Queen's Gardens")]
+        [Description("Queen's Gardens Cornifer (Bench)"), ToolTip("Splits when sitting on the bench by Cornifer in Queen's Gardens")]
         BenchQGCornifer,
         [Description("Queen's Gardens Toll (Bench)"), ToolTip("Splits when sitting on the toll bench in Queen's Gardens")]
         BenchQGToll,
@@ -1391,7 +1391,7 @@ namespace LiveSplit.HollowKnight {
         BenchHallOfGods,
         */
 
-        [Description("Queen's Garden Bench (Toll)"), ToolTip("Splits when buying Queen's Garden toll bench")]
+        [Description("Queen's Gardens Bench (Toll)"), ToolTip("Splits when buying Queen's Gardens toll bench")]
         TollBenchQG,
         [Description("Sanctum Bench (Toll)"), ToolTip("Splits when buying City/Sanctum toll bench by Cornifer's location")]
         TollBenchCity,


### PR DESCRIPTION
Adds a transition autosplit for entering either Queen's Gardens or Deepnest. Intended to be used in "flexible" Any% splits so that runners can choose to go through either QGA route or Deepnest route.

Branch with the dll for testing: https://github.com/AlexKnauth/LiveSplit.HollowKnight/tree/EnterQueensGardensOrDeepnest-dll
- [x] Splits on QGA entrance to QG
- [x] Splits on Wraiths entrance to QG
- [x] Splits on Deepnest entrance near Spore Shroom
- [x] Splits on Deepnest entrance from Tram: after `Deepnest Tram station: Abyss_03b -> Abyss_03_b`

Resolves #139 