### PR TITLE
On unordered splits, set a custom variable to show which split triggered it

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -101,6 +101,7 @@ namespace LiveSplit.HollowKnight {
                 }
                 state.Run.Metadata.SetCustomVariable("comparison hits", TimeFormatConstants.DASH);
                 state.Run.Metadata.SetCustomVariable("delta hits", TimeFormatConstants.DASH);
+                state.Run.Metadata.SetCustomVariable("item", "");
 
                 if (state.CurrentTimingMethod == TimingMethod.RealTime) {
                     var timingMessage = MessageBox.Show(
@@ -328,6 +329,8 @@ namespace LiveSplit.HollowKnight {
                     continue;
                 } else if (Split.ToString().StartsWith("Menu") || !((gameState == GameState.INACTIVE && uIState == UIState.INACTIVE) || (gameState == GameState.MAIN_MENU))) {
                     if (CheckSplit(Split, nextScene, sceneName) == SplitterAction.Split) {
+                        // item = split description name without qualifier in parentheses
+                        Model.CurrentState.Run.Metadata.SetCustomVariable("item", HollowKnightSplitSettings.SplitDescriptionName(HollowKnightSplitSettings.GetSplitDescription(Split)));
                         splitsDone.Add(Split);
                         lastSplitDone = Split;
                         menuSplitHelper = false;
@@ -2389,6 +2392,7 @@ namespace LiveSplit.HollowKnight {
             menuSplitCountdown = 20;
             store.SplitThisTransition = true;
             store.Update();
+            Model.CurrentState.Run.Metadata.SetCustomVariable("item", "");
         }
         public Control GetSettingsControl(LayoutMode mode) { return settings; }
         public void SetSettings(XmlNode document) {

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using System.Windows.Forms.VisualStyles;
 
@@ -28,14 +29,37 @@ namespace LiveSplit.HollowKnight {
         public static SplitName GetSplitName(string text) {
             foreach (SplitName split in Enum.GetValues(typeof(SplitName))) {
                 string name = split.ToString();
-                MemberInfo info = typeof(SplitName).GetMember(name)[0];
-                DescriptionAttribute description = (DescriptionAttribute)info.GetCustomAttributes(typeof(DescriptionAttribute), false)[0];
+                string description = GetSplitDescription(split);
 
-                if (name.Equals(text, StringComparison.OrdinalIgnoreCase) || description.Description.Equals(text, StringComparison.OrdinalIgnoreCase)) {
+                if (name.Equals(text, StringComparison.OrdinalIgnoreCase) || description.Equals(text, StringComparison.OrdinalIgnoreCase)) {
                     return split;
                 }
             }
             return SplitName.ManualSplit;
+        }
+
+        /// <summary>
+        /// Gets the split description of the given split
+        /// </summary>
+        /// <param name="split">Split to look up</param>
+        /// <returns>Split description including both name and qualifier in parentheses</returns>
+        public static string GetSplitDescription(SplitName split) {
+            MemberInfo info = typeof(SplitName).GetMember(split.ToString())[0];
+            DescriptionAttribute description = (DescriptionAttribute)info.GetCustomAttributes(typeof(DescriptionAttribute), false)[0];
+            return description.Description;
+        }
+        /// <summary>
+        /// Removes the qualifier in parentheses from a split description, producing only the name
+        /// </summary>
+        /// <param name="description">Split description</param>
+        /// <returns>Name without qualifier</returns>
+        public static string SplitDescriptionName(string description) {
+            Match m = Regex.Match(description, "(?<name>.+)\\s+\\(.+\\)");
+            if (m.Success) {
+                return m.Groups["name"].Value;
+            } else {
+                return description;
+            }
         }
 
         private void picHandle_MouseMove(object sender, MouseEventArgs e) {


### PR DESCRIPTION
Resolves #144.

When not on Ordered splits, sets a custom variable `item` to the split name that triggered it.

Intended to be used with the upcoming Custom Variable Columns feature (currently in the LiveSplit Development Version), in settings such as Randomizer or All Skills Shuffle, for splitting on major items in whatever order they come in, and filling in which items they were on the splits as they advance.

Currently a Draft PR because the Custom Variable Columns feature is not yet released on the current stable LiveSplit version 1.8.33. Once the next LiveSplit version comes out, I'll convert from a Draft to a Ready PR.